### PR TITLE
[#5] Split lint and test into separate CI jobs.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -17,6 +17,37 @@ on:
         default: false
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-normal-${{ hashFiles('**/composer.lock') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Validate composer.json
+        run: |
+          composer --verbose validate
+          composer normalize --dry-run
+
+      - name: Check coding standards
+        run: composer lint
+        continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
+
   test-php:
     name: PHP ${{ matrix.php-versions }}, Deps ${{ matrix.deps }}
     runs-on: ubuntu-latest
@@ -56,11 +87,6 @@ jobs:
         run: |
           composer --verbose validate
           composer normalize --dry-run
-
-      - name: Check coding standards
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
-        run: composer lint
-        continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
       - name: Run tests
         run: composer test-coverage


### PR DESCRIPTION
Closes #5

## Summary

Extracted the linting step from the matrix-based `test-php` job into a dedicated `lint` job that runs independently. Previously, linting only executed for one specific matrix combination (`php-versions == '8.3'` and `deps == 'normal'`), meaning it was coupled to the test matrix. The new `lint` job runs on PHP 8.3 with normal deps as its own CI job, making it easier to see lint vs. test failures at a glance.

## Changes

**`.github/workflows/test-php.yml`**
- Added a new `lint` job with its own checkout, Composer cache, PHP setup, dependency install, composer validation, and coding standards steps
- Removed the conditional `Check coding standards` step from the `test-php` matrix job, which was gated by `matrix.php-versions == '8.3' && matrix.deps == 'normal'`

## Before / After

```
Before:
┌─────────────────────────────────────────────────────┐
│ Job: test-php (matrix: php-versions × deps)         │
│  ├── Checkout                                        │
│  ├── Cache Composer                                  │
│  ├── Setup PHP                                       │
│  ├── Install dependencies                            │
│  ├── Validate composer.json                          │
│  ├── Check coding standards  ← only if 8.3 + normal │
│  └── Run tests                                       │
└─────────────────────────────────────────────────────┘

After:
┌──────────────────────────┐  ┌────────────────────────────┐
│ Job: lint                │  │ Job: test-php (matrix)     │
│  ├── Checkout            │  │  ├── Checkout              │
│  ├── Cache Composer      │  │  ├── Cache Composer        │
│  ├── Setup PHP (8.3)     │  │  ├── Setup PHP             │
│  ├── Install deps        │  │  ├── Install dependencies  │
│  ├── Validate composer   │  │  ├── Validate composer.json│
│  └── Check coding stds   │  │  └── Run tests             │
└──────────────────────────┘  └────────────────────────────┘
```
