### PR TITLE
Fixed embedding issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - ⚙️ [**Configuration**](#configuration) — symbols, colors, spacing, labels, env prefix, truthy/falsy values
 - 🧪 [**Test harness**](#test-harness) — `PromptyTestTrait` injects keystrokes for PHPUnit testing
 - 🚀 [**Starter script**](#starter-script) — [`starter.php`](starter.php) as a template for your own scripts
+- 📥 [**Embedding**](#embedding) — minify and embed the class directly into your script
 
 ## Zero dependencies
 
@@ -58,6 +59,8 @@ $name = Prompty::text('Project name');
 
 Or [embed](#embedding) the minified class directly into your script to ship a
 single file with no external dependencies.
+
+You may also use the [starter](#starter-script) as a template for your own scripts.
 
 ### Composer projects — require as a package
 
@@ -581,19 +584,37 @@ Embed into a separate output file (source stays unchanged):
 php embed.php my-script.php dist/my-script.php
 ```
 
-Use `--compact` to apply additional size optimizations (shortens internal
-property and method names, renames local variables, reduces whitespace):
+Use `--compact` to collapse the entire class into a single line (plus the
+license header comment):
 
 ```bash
 php embed.php --compact my-script.php
 ```
 
-The script replaces everything between the markers with the minified class,
-preserving the license header. It runs `php -l` on the result to verify the
-output is valid PHP. Wrap the markers in `// phpcs:disable` / `// phpcs:enable`
+Wrap the markers in `// phpcs:disable` / `// phpcs:enable`
 to suppress coding standard warnings on the minified code.
 
 See [`starter.php`](starter.php) for an example with markers already in place.
+
+### Kill switch
+
+If your script does not already contain a kill-switch statement, `embed.php`
+will automatically inject one after the embed region. This allows tests to run
+the script without executing the real work below:
+
+```php
+// Kill switch — stop here when running under tests.
+// In production, set SHOULD_PROCEED=1 to continue past this point.
+if (!getenv('SHOULD_PROCEED')) {
+  return;
+}
+```
+
+Use `--no-killswitch` to skip the injection:
+
+```bash
+php embed.php --no-killswitch my-script.php
+```
 
 ## Maintenance
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "opis/closure": "^4.4",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^11.5",
-        "rector/rector": "^2"
+        "rector/rector": "^2.3.9"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/embed.php
+++ b/embed.php
@@ -9,7 +9,8 @@
  * @see https://github.com/AlexSkrypnyk/prompty
  *
  * Usage:
- *   php embed.php [--compact] <source-script> [<output-script>]
+ *   php embed.php [--compact] [--no-killswitch] <source>
+ *                 [<output>]
  *   php embed.php [--compact] --stdout <output-file>
  *
  * The source script must contain // @embed-start and // @embed-end markers.
@@ -19,11 +20,20 @@
  * embedding is performed on the copy. Otherwise the source is modified
  * in place.
  *
+ * After embedding, if Rector is available (vendor/bin/rector), it will be
+ * run on the processed class content. A kill-switch block is injected after
+ * the embed region if one is not already present. The embedded script is
+ * then run to verify it works.
+ *
  * Options:
- *   --compact  Apply additional size optimizations: shorten internal property
- *              and method names, rename local variables, reduce whitespace.
- *   --stdout   Output the processed class as a standalone PHP file instead of
- *              embedding into a target script. Requires an output file path.
+ *   --compact        Apply additional size optimizations: shorten internal
+ *                    property and method names, rename local variables,
+ *                    reduce whitespace.
+ *   --stdout         Output the processed class as a standalone PHP file
+ *                    instead of embedding into a target script. Requires an
+ *                    output file path.
+ *   --no-killswitch  Skip injecting the kill-switch block and post-embed
+ *                    verification run.
  */
 
 declare(strict_types=1);
@@ -39,6 +49,7 @@ define('EMBED_MARKER_END', '@embed-end');
 // Argument parsing.
 $compact = FALSE;
 $stdout = FALSE;
+$no_killswitch = FALSE;
 $positional = [];
 
 for ($arg_i = 1; $arg_i < $argc; $arg_i++) {
@@ -48,13 +59,16 @@ for ($arg_i = 1; $arg_i < $argc; $arg_i++) {
   elseif ($argv[$arg_i] === '--stdout') {
     $stdout = TRUE;
   }
+  elseif ($argv[$arg_i] === '--no-killswitch') {
+    $no_killswitch = TRUE;
+  }
   else {
     $positional[] = $argv[$arg_i];
   }
 }
 
 if ($positional === []) {
-  fwrite(STDERR, "Usage: php embed.php [--compact] [--stdout] <source-script> [<output-script>]\n");
+  fwrite(STDERR, "Usage: php embed.php [--compact] [--no-killswitch] [--stdout] <source-script> [<output-script>]\n");
   exit(1);
 }
 
@@ -576,6 +590,39 @@ if (preg_match('/^\s*namespace\s+(.+?)\s*;/m', $source, $ns_match)) {
 
 $class_content = preg_replace('/^\s+|\s+$/', '', $minified) . "\n";
 
+// Add phpstan-ignore-next-line before the class declaration.
+$class_content = preg_replace('/^(class\s)/m', "// @phpstan-ignore-next-line\n$1", $class_content, 1);
+
+// Run Rector on the processed class content if available.
+$rector_bin = __DIR__ . '/vendor/bin/rector';
+$rector_config = __DIR__ . '/rector.php';
+
+if (is_file($rector_bin) && is_file($rector_config)) {
+  $rector_tmp = tempnam(sys_get_temp_dir(), 'embed_rector_');
+  rename($rector_tmp, $rector_tmp . '.php');
+  $rector_tmp .= '.php';
+
+  // Wrap class content in a valid PHP file for rector.
+  $rector_input = "<?php\n\ndeclare(strict_types=1);\n\n" . $class_content;
+  file_put_contents($rector_tmp, $rector_input);
+
+  $rector_output = [];
+  $rector_exit = 0;
+  exec('php ' . escapeshellarg($rector_bin) . ' process --no-ansi --config=' . escapeshellarg($rector_config) . ' ' . escapeshellarg($rector_tmp) . ' 2>&1', $rector_output, $rector_exit);
+
+  if ($rector_exit <= 1) {
+    // Read back the processed content and strip the PHP preamble.
+    $rector_result = file_get_contents($rector_tmp);
+    if ($rector_result !== FALSE) {
+      $rector_result = preg_replace('/^<\?php\s+declare\(strict_types\s*=\s*1\)\s*;\s*/s', '', $rector_result);
+      $class_content = preg_replace('/^\s+|\s+$/', '', (string) $rector_result) . "\n";
+    }
+  }
+
+  unlink($rector_tmp);
+  echo sprintf('Rector: processed.%s', PHP_EOL);
+}
+
 if ($stdout) {
   // --stdout mode: write a standalone PHP file.
   $standalone = "<?php\n\ndeclare(strict_types=1);\n\n";
@@ -603,9 +650,6 @@ if ($stdout) {
 
 // Build and inject the embedded block.
 $embedded = '// ' . EMBED_MARKER_START . "\n";
-if ($namespace !== '') {
-  $embedded .= "namespace {$namespace};\n\n";
-}
 $embedded .= $class_content;
 $embedded .= '// ' . EMBED_MARKER_END;
 
@@ -643,6 +687,29 @@ if ($namespace !== '') {
 }
 $result = preg_replace('/\n{3,}/', "\n\n", $result ?? '');
 
+// Inject kill switch if not present and not opted out.
+$has_killswitch = str_contains((string) $result, "if (!getenv('SHOULD_PROCEED'))");
+
+if (!$has_killswitch && !$no_killswitch) {
+  $killswitch = <<<'KILLSWITCH'
+
+// Kill switch — stop here when running under tests.
+// In production, set SHOULD_PROCEED=1 to continue past this point.
+if (!getenv('SHOULD_PROCEED')) {
+  return;
+}
+KILLSWITCH;
+
+  // Insert after the // phpcs:enable line if present, otherwise
+  // after @embed-end.
+  if (str_contains((string) $result, '// phpcs:enable')) {
+    $result = preg_replace('/(\/\/ phpcs:enable\n)/', '$1' . $killswitch, (string) $result, 1);
+  }
+  else {
+    $result = preg_replace('/(\/\/ ' . preg_quote(EMBED_MARKER_END, '/') . '[^\n]*\n)/', '$1' . $killswitch, (string) $result, 1);
+  }
+}
+
 // Write the result.
 file_put_contents($target_path, $result);
 
@@ -658,3 +725,47 @@ if ($lint_exit !== 0) {
 }
 
 echo sprintf('Embedded into %s%s', $target_path, PHP_EOL);
+
+// Check final kill switch state for warnings.
+$final_content = file_get_contents($target_path);
+$final_has_killswitch = $final_content !== FALSE && str_contains($final_content, "if (!getenv('SHOULD_PROCEED'))");
+
+if (!$final_has_killswitch) {
+  echo "\033[33mWarning: No kill switch found in the target file. Please test the embedded script manually.\033[0m" . PHP_EOL;
+}
+elseif (posix_isatty(STDIN)) {
+  // Run the embedded script to verify it works (only in interactive mode).
+  echo sprintf('Verifying embedded script (interactive input required)...%s', PHP_EOL);
+
+  $verify_exit = 0;
+  passthru('php ' . escapeshellarg($target_path), $verify_exit);
+
+  if ($verify_exit !== 0) {
+    fwrite(STDERR, sprintf("Warning: Embedded script exited with code %d.%s", $verify_exit, PHP_EOL));
+  }
+}
+else {
+  echo sprintf('Verifying embedded script...%s', PHP_EOL);
+
+  // Non-interactive mode: pipe keystrokes to simulate a quick run.
+  $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+  $verify_proc = proc_open('php ' . escapeshellarg($target_path), $descriptors, $verify_pipes);
+
+  if (is_resource($verify_proc)) {
+    // Send minimal input to get through the flow, then close stdin.
+    fwrite($verify_pipes[0], "\n\n\n\n");
+    fclose($verify_pipes[0]);
+
+    stream_get_contents($verify_pipes[1]);
+    fclose($verify_pipes[1]);
+
+    stream_get_contents($verify_pipes[2]);
+    fclose($verify_pipes[2]);
+
+    $verify_exit = proc_close($verify_proc);
+
+    if ($verify_exit !== 0) {
+      fwrite(STDERR, sprintf("Warning: Embedded script exited with code %d.%s", $verify_exit, PHP_EOL));
+    }
+  }
+}

--- a/tests/phpunit/Unit/EmbedScriptTest.php
+++ b/tests/phpunit/Unit/EmbedScriptTest.php
@@ -85,6 +85,18 @@ final class EmbedScriptTest extends TestCase {
     // ANSI escape sequences preserved.
     $this->assertStringContainsString('\033[', $content);
 
+    // Namespace removed from embedded output.
+    $this->assertDoesNotMatchRegularExpression(
+      '/^namespace\s+AlexSkrypnyk\\\\Prompty\s*;/m',
+      $content,
+    );
+
+    // PHPStan ignore comment added before class declaration.
+    $this->assertMatchesRegularExpression(
+      '/\/\/ @phpstan-ignore-next-line\nclass Prompty/',
+      $content,
+    );
+
     // Embedded script runs correctly in a subprocess.
     $this->assertEmbeddedScriptWorks($target);
   }
@@ -258,6 +270,153 @@ final class EmbedScriptTest extends TestCase {
     $this->assertStringNotContainsString('renderCompleted', $content);
   }
 
+  public function testEmbedRunsRector(): void {
+    $target = $this->prepareTarget();
+
+    // Capture embed output to verify rector message.
+    $embed_output = $this->runEmbedWithOutput($target);
+    $this->assertStringContainsString('Rector', $embed_output);
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+    $this->assertStringContainsString('class Prompty', $content);
+
+    // Run rector --dry-run to confirm no further changes needed.
+    $rector_config = $this->createRectorConfig();
+    $output = [];
+    $exit_code = 0;
+    exec(
+      'php ' . escapeshellarg(__DIR__ . '/../../../vendor/bin/rector') . ' process --dry-run --config=' . escapeshellarg($rector_config) . ' ' . escapeshellarg($target) . ' 2>&1',
+      $output,
+      $exit_code,
+    );
+    $this->assertSame(0, $exit_code, 'Rector would make further changes: ' . implode("\n", $output));
+  }
+
+  public function testEmbedStdoutRunsRector(): void {
+    $output_path = $this->tmpDir . '/Prompty.rector.php';
+
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $cmd_output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --stdout ' . escapeshellarg($output_path) . ' 2>&1', $cmd_output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Embed --stdout failed: ' . implode("\n", $cmd_output));
+    $this->assertStringContainsString('Rector', implode("\n", $cmd_output));
+
+    // Run rector --dry-run to confirm no further changes needed.
+    $rector_config = $this->createRectorConfig();
+    $output = [];
+    $exit_code = 0;
+    exec(
+      'php ' . escapeshellarg(__DIR__ . '/../../../vendor/bin/rector') . ' process --dry-run --config=' . escapeshellarg($rector_config) . ' ' . escapeshellarg($output_path) . ' 2>&1',
+      $output,
+      $exit_code,
+    );
+    $this->assertSame(0, $exit_code, 'Rector would make further changes on stdout output: ' . implode("\n", $output));
+  }
+
+  public function testEmbedKillswitchAlreadyPresent(): void {
+    $target = $this->prepareTarget();
+
+    $this->runEmbed($target);
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+
+    // Kill switch already existed in starter.php — should not be duplicated.
+    $this->assertSame(
+      1,
+      substr_count($content, "if (!getenv('SHOULD_PROCEED'))"),
+      'Kill switch should appear exactly once.',
+    );
+  }
+
+  public function testEmbedKillswitchInjected(): void {
+    $target = $this->prepareTargetWithoutKillswitch();
+
+    $this->runEmbed($target);
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+
+    // Kill switch should have been injected.
+    $this->assertStringContainsString("if (!getenv('SHOULD_PROCEED'))", $content);
+
+    // Should appear after the @embed-end marker.
+    $embed_end_pos = strpos($content, '@embed-end');
+    $killswitch_pos = strpos($content, "if (!getenv('SHOULD_PROCEED'))");
+    $this->assertNotFalse($embed_end_pos);
+    $this->assertNotFalse($killswitch_pos);
+    $this->assertGreaterThan($embed_end_pos, $killswitch_pos);
+  }
+
+  public function testEmbedRunsVerification(): void {
+    $target = $this->prepareTarget();
+
+    // Run embed with simulated keystrokes for the interactive verification.
+    $keystrokes = $this->promptyKeys(
+      'my-project', self::KEY_ENTER,
+      self::KEY_DOWN, self::KEY_ENTER,
+      self::KEY_SPACE, self::KEY_ENTER,
+      self::KEY_ENTER,
+    );
+
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $descriptors = [
+      0 => ['pipe', 'r'],
+      1 => ['pipe', 'w'],
+      2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open(
+      'php ' . escapeshellarg($embed_script) . ' ' . escapeshellarg($target),
+      $descriptors,
+      $pipes,
+    );
+    $this->assertIsResource($process);
+
+    fwrite($pipes[0], $keystrokes);
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    $exit_code = proc_close($process);
+    $this->assertSame(0, $exit_code, 'Embed with verification failed: ' . $stderr);
+
+    // Verification message should appear in output.
+    $this->assertIsString($stdout);
+    $this->assertStringContainsString('Verifying', $stdout);
+  }
+
+  public function testEmbedSkipsVerificationWithoutKillswitch(): void {
+    $target = $this->prepareTargetWithoutKillswitch();
+
+    $embed_output = $this->runEmbedWithOutput($target, ['--no-killswitch']);
+
+    // Should show yellow warning about skipping verification.
+    $this->assertStringContainsString('no kill switch', strtolower($embed_output));
+    $this->assertStringNotContainsString('Verifying', $embed_output);
+  }
+
+  public function testEmbedNoKillswitchFlag(): void {
+    $target = $this->prepareTargetWithoutKillswitch();
+
+    $embed_output = $this->runEmbedWithOutput($target, ['--no-killswitch']);
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+
+    // Kill switch should NOT have been injected.
+    $this->assertStringNotContainsString("if (!getenv('SHOULD_PROCEED'))", $content);
+
+    // Warning should have been shown.
+    $this->assertStringContainsString('no kill switch', strtolower($embed_output));
+  }
+
   public function testEmbedErrors(): void {
     // Missing argument.
     $output = [];
@@ -296,7 +455,16 @@ final class EmbedScriptTest extends TestCase {
    * @param list<string> $extra_args
    *   Additional CLI arguments.
    */
-  protected function runEmbed(string $target, array $extra_args = []): void {
+
+  /**
+   * Run the embed script and return its combined output.
+   *
+   * @param string $target
+   *   Path to the target file.
+   * @param list<string> $extra_args
+   *   Additional CLI arguments.
+   */
+  protected function runEmbedWithOutput(string $target, array $extra_args = []): string {
     $embed_script = __DIR__ . '/../../../embed.php';
     $cmd = 'php ' . escapeshellarg($embed_script);
     foreach ($extra_args as $extra_arg) {
@@ -306,7 +474,55 @@ final class EmbedScriptTest extends TestCase {
     $output = [];
     $exit_code = 0;
     exec($cmd . ' 2>&1', $output, $exit_code);
+    $combined = implode("\n", $output);
+    $this->assertSame(0, $exit_code, 'Embed script failed: ' . $combined);
+
+    return $combined;
+  }
+
+  protected function runEmbed(string $target, array $extra_args = []): void {
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $cmd = 'php ' . escapeshellarg($embed_script);
+    foreach ($extra_args as $extra_arg) {
+      $cmd .= ' ' . escapeshellarg((string) $extra_arg);
+    }
+    $cmd .= ' ' . escapeshellarg($target);
+    $output = [];
+    $exit_code = 0;
+    exec($cmd . ' 2>&1', $output, $exit_code);
     $this->assertSame(0, $exit_code, 'Embed script failed: ' . implode("\n", $output));
+  }
+
+  /**
+   * Copy starter.php to temp dir without the kill switch block.
+   */
+  protected function prepareTargetWithoutKillswitch(): string {
+    $source = __DIR__ . '/../../../starter.php';
+    $content = file_get_contents($source);
+    $this->assertIsString($content);
+
+    // Remove the kill switch block.
+    $content = preg_replace(
+      '/\/\/ Kill switch.*?if \(!getenv\(\'SHOULD_PROCEED\'\)\) \{\s*return;\s*\}\n*/s',
+      '',
+      $content,
+    );
+    $this->assertIsString($content);
+
+    $target = $this->tmpDir . '/starter_no_ks.php';
+    file_put_contents($target, $content);
+
+    return $target;
+  }
+
+  /**
+   * Create a rector config file suitable for testing embedded output.
+   */
+  protected function createRectorConfig(): string {
+    $config_path = $this->tmpDir . '/rector.php';
+    copy(__DIR__ . '/../../../rector.php', $config_path);
+
+    return $config_path;
   }
 
   /**
@@ -325,8 +541,7 @@ final class EmbedScriptTest extends TestCase {
     file_put_contents($wrapper, "<?php\n"
       . "declare(strict_types=1);\n"
       . "require_once '{$escaped_target}';\n"
-      . ('echo json_encode(' . Prompty::class . '::results());
-')
+      . "echo json_encode(Prompty::results());\n"
     );
 
     $descriptors = [


### PR DESCRIPTION
## Summary

- Added `// @phpstan-ignore-next-line` before the embedded class declaration.
- Removed `namespace AlexSkrypnyk\Prompty;` from embedded output (kept in `--stdout` mode).
- Added Rector processing on minified/compact output before embedding.
- Added automatic kill-switch injection after embed region when not already present; `--no-killswitch` flag to opt out.
- Added post-embed verification run (interactive via `passthru`, non-interactive via `proc_open`); shows yellow warning if no kill switch is present.
- Updated usage docs in `embed.php` header and README.

## Test plan

- [x] Existing `testEmbed` asserts phpstan-ignore line and namespace removal.
- [x] `testEmbedRunsRector` and `testEmbedStdoutRunsRector` verify Rector processing.
- [x] `testEmbedKillswitchAlreadyPresent` verifies no duplicate injection.
- [x] `testEmbedKillswitchInjected` verifies injection when missing.
- [x] `testEmbedNoKillswitchFlag` verifies opt-out and warning.
- [x] `testEmbedRunsVerification` verifies post-embed script run.
- [x] `testEmbedSkipsVerificationWithoutKillswitch` verifies skip and warning.
- [x] All 289 tests pass, lint clean.