### PR TITLE
[#13] Added `version()` support.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           php-version: '8.3'
 
+      - name: Imprint version
+        run: sed -i "s/__PROMPTY_VERSION__/${GITHUB_REF_NAME}/g" Prompty.php
+
       - name: Verify starter script
         run: |
           echo -e "test\n\n\n\n" | php starter.php

--- a/Prompty.php
+++ b/Prompty.php
@@ -253,6 +253,20 @@ class Prompty {
   }
 
   /**
+   * Get the library version.
+   *
+   * Returns 'development' when the version token has not been replaced
+   * (i.e. running from source). During release, the __PROMPTY_VERSION__
+   * token is replaced with the actual tag via sed.
+   *
+   * @return string
+   *   The version string.
+   */
+  public static function version(): string {
+    return str_starts_with('__PROMPTY_VERSION__', '__') ? 'development' : '__PROMPTY_VERSION__';
+  }
+
+  /**
    * Configure the singleton instance.
    *
    * Creates the singleton if it does not exist yet. Call before any widgets

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Features
 
-- 📦 [**Zero dependencies**](#zero-dependencies) — drop `Prompty.php` into your project or [embed](#embedding) into your script
+- 📦 [**Zero dependencies**](#installation) — drop `Prompty.php` into your project or [embed](#embedding) into your script
 - 🧩 [**Widgets**](#widgets) — `text`, `select`, `multiselect`, `confirm`
 - 🔀 [**Flows**](#flows) — group prompts into a wizard with intro/outro, numbering, and cancellation
 - 🌳 [**Nested flows**](#nested-flows-with-conditions) — conditional children rendered as a tree
@@ -39,49 +39,52 @@
 - 🚀 [**Starter script**](#starter-script) — [`starter.php`](starter.php) as a template for your own scripts
 - 📥 [**Embedding**](#embedding) — minify and embed the class directly into your script
 
-## Zero dependencies
+## Installation
 
-Prompty is a single PHP file with no dependencies. There are two ways to use it:
+Prompty is a single PHP file with zero dependencies.
 
-### Simple scripts — just copy the file
+### Download from releases
 
-Download `Prompty.php` and `require_once` it directly:
+Download `Prompty.php` from the
+[latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest)
+assets.
 
-```bash
-curl -O https://raw.githubusercontent.com/alexskrypnyk/prompty/main/Prompty.php
-```
+Three variants are available:
 
-```php
-require_once __DIR__ . '/Prompty.php';
+| Asset                 | Description                                        |
+|-----------------------|----------------------------------------------------|
+| `Prompty.php`         | Full source with version imprinted                 |
+| `Prompty.min.php`     | Minified — comments and blank lines stripped       |
+| `Prompty.compact.php` | Compacted — single-line class, shortened internals |
 
-$name = Prompty::text('Project name');
-```
+For testing, also download `PromptyTestTrait.php` from the same release.
 
-Or [embed](#embedding) the minified class directly into your script to ship a
-single file with no external dependencies.
+See [Usage](#usage) for how to embed the class directly into your script.
 
-You may also use the [starter](#starter-script) as a template for your own scripts.
-
-### Composer projects — require as a package
-
-For larger projects with Composer:
+### Composer
 
 ```bash
 composer require alexskrypnyk/prompty
 ```
 
-Then use it like any other class — the autoloader handles the rest:
+`PromptyTestTrait` is included in the package.
+
+## Usage
+
+Require the file and use the class directly:
 
 ```php
+require_once __DIR__ . '/Prompty.php';
+
+use AlexSkrypnyk\Prompty\Prompty;
+
 $name = Prompty::text('Project name');
 ```
 
-For testing, `PromptyTestTrait` is included in the package. If you're using the
-copy approach, grab it separately:
+Or [embed](#embedding) the minified class directly into your script (using
+provided minification script) to ship a single file with no external dependencies.
 
-```bash
-curl -O https://raw.githubusercontent.com/alexskrypnyk/prompty/main/PromptyTestTrait.php
-```
+You may also use the [starter](#starter-script) as a template for your own scripts.
 
 ## Widgets
 
@@ -548,6 +551,10 @@ Copy `starter.php`, rename it, and replace the steps with your own.
 [`embed.php`](embed.php) minifies `Prompty.php` (strips comments, collapses
 blank lines) and embeds it directly into your script — so you can ship a single
 file with no `require_once` and no external dependencies.
+
+Download `embed.php` from the
+[latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest)
+assets alongside `Prompty.php`.
 
 ### Setup
 

--- a/tests/phpunit/Unit/Prompty/PromptyConfigTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyConfigTest.php
@@ -359,6 +359,10 @@ final class PromptyConfigTest extends PromptyTestCase {
     $this->assertSame($original_prefix, $this->getProperty($p, 'cfgEnvPrefix'));
   }
 
+  public function testVersionReturnsDevelopment(): void {
+    $this->assertSame('development', Prompty::version());
+  }
+
   public function testSingletonCreation(): void {
     $this->setStaticProperty('instance', NULL);
 

--- a/tests/phpunit/Unit/StarterScriptTest.php
+++ b/tests/phpunit/Unit/StarterScriptTest.php
@@ -104,6 +104,64 @@ final class StarterScriptTest extends TestCase {
     $this->assertFalse($results['install']);
   }
 
+  public function testVersionAfterImprinting(): void {
+    $tmp_dir = __DIR__ . '/../../../.artifacts/tmp/version_test_' . getmypid();
+    mkdir($tmp_dir, 0755, TRUE);
+
+    // Embed Prompty into a temp copy of starter.php.
+    $target = $tmp_dir . '/starter.php';
+    copy(__DIR__ . '/../../../starter.php', $target);
+
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --no-killswitch ' . escapeshellarg($target) . ' 2>&1', $output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Embed failed: ' . implode("\n", $output));
+
+    // Simulate release version imprinting via sed.
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+    $content = str_replace('__PROMPTY_VERSION__', '1.2.3', $content);
+
+    // Inject version output before the kill switch.
+    $content = str_replace(
+      "if (!getenv('SHOULD_PROCEED'))",
+      "echo 'VERSION:' . Prompty::version() . PHP_EOL;\nif (!getenv('SHOULD_PROCEED'))",
+      $content,
+    );
+    file_put_contents($target, $content);
+
+    // Run the script with piped keystrokes to get through the flow.
+    $keystrokes = $this->promptyKeys(
+      'test', self::KEY_ENTER,
+      self::KEY_ENTER,
+      self::KEY_ENTER,
+      self::KEY_ENTER,
+    );
+
+    $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+    $process = proc_open('php ' . escapeshellarg($target), $descriptors, $pipes);
+    $this->assertIsResource($process);
+
+    fwrite($pipes[0], $keystrokes);
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    $exit_code = proc_close($process);
+    $this->assertSame(0, $exit_code, 'Script failed: ' . $stderr);
+    $this->assertIsString($stdout);
+    $this->assertStringContainsString('VERSION:1.2.3', $stdout);
+
+    // Clean up.
+    array_map(unlink(...), glob($tmp_dir . '/*') ?: []);
+    rmdir($tmp_dir);
+  }
+
   public function testStarterOutputContainsIntroOutro(): void {
     $keystrokes = $this->promptyKeys(
       self::KEY_ENTER,


### PR DESCRIPTION
Closes #13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request implements version retrieval support for Prompty by adding a `version()` static method and establishing build-time version imprinting. The implementation resolves issue #13.

## Changes

### Core Implementation
- **Prompty.php**: Added `Prompty::version()` public static method that returns `'development'` when the `__PROMPTY_VERSION__` token is unreplaced, otherwise returns the imprinted release version.

### Release Automation
- **.github/workflows/release.yml**: Added "Imprint version" step that uses `sed` to replace the `__PROMPTY_VERSION__` placeholder with the GitHub release tag during the release workflow.

### Testing
- **tests/phpunit/Unit/Prompty/PromptyConfigTest.php**: Added `testVersionReturnsDevelopment()` unit test verifying that `Prompty::version()` returns `'development'` in development builds.
- **tests/phpunit/Unit/StarterScriptTest.php**: Added `testVersionAfterImprinting()` functional test that validates version replacement in the starter script post-embedding and verifies the version is correctly retrieved at runtime.

### Documentation
- **README.md**: Updated installation guidance to clarify downloading pre-built variants (`Prompty.php`, `Prompty.min.php`, `Prompty.compact.php`) from releases rather than the repository. Added "Installation" and "Usage" sections and updated "Embedding" instructions to reference downloading `embed.php` from the latest release.

## Implementation Details

The version system uses a token-based approach: the `__PROMPTY_VERSION__` placeholder remains in development builds (returning "development"), while release workflows replace it with the actual version tag during packaging. This ensures development builds are not version-bumped on every commit while maintaining accurate versioning for released assets.

Closes #13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->