### PR TITLE
[#12] Added '--source' flag and re-embedding support to embed.php.

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,64 @@ Use `--no-killswitch` to skip the injection:
 php embed.php --no-killswitch my-script.php
 ```
 
+### For AI agents
+
+<details>
+<summary>Embed into starter script</summary>
+
+```bash
+# Download Prompty.php, embed.php, and the starter template.
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/embed.php
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/starter.php
+
+# Rename the starter to your script name.
+mv starter.php my-script.php
+
+# Embed the minified class into the script.
+php embed.php my-script.php
+```
+
+</details>
+
+<details>
+<summary>Embed into custom script</summary>
+
+```bash
+# Download Prompty.php and embed.php.
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/embed.php
+
+# Add markers in your script around the require_once line:
+#
+#   // phpcs:disable
+#   // @embed-start
+#   require_once __DIR__ . '/Prompty.php';
+#   // @embed-end
+#   // phpcs:enable
+
+# Embed the minified class into the script.
+php embed.php my-script.php
+```
+
+</details>
+
+<details>
+<summary>Update Prompty</summary>
+
+```bash
+# Download the new Prompty.php, overwriting the old one.
+curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
+
+# Re-run the embedder. Code outside the markers is preserved.
+php embed.php my-script.php
+
+# Or use --source if the new Prompty.php is in a different location.
+php embed.php --source /path/to/new/Prompty.php my-script.php
+```
+
+</details>
+
 ## Maintenance
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -598,10 +598,34 @@ license header comment):
 php embed.php --compact my-script.php
 ```
 
+Use `--source` to specify an alternative path to the class file to embed
+(defaults to `Prompty.php` in the same directory as `embed.php`):
+
+```bash
+php embed.php --source /path/to/Prompty.php my-script.php
+```
+
 Wrap the markers in `// phpcs:disable` / `// phpcs:enable`
 to suppress coding standard warnings on the minified code.
 
 See [`starter.php`](starter.php) for an example with markers already in place.
+
+### Re-embedding
+
+To update an already-embedded script to a newer version of Prompty, replace
+`Prompty.php` with the new version and re-run `embed.php`. The embedded region
+is replaced with the latest class content while all code outside the markers is
+preserved:
+
+```bash
+php embed.php my-script.php
+```
+
+If the new `Prompty.php` is in a different location, use `--source`:
+
+```bash
+php embed.php --source /path/to/new/Prompty.php my-script.php
+```
 
 ### Kill switch
 

--- a/embed.php
+++ b/embed.php
@@ -9,12 +9,13 @@
  * @see https://github.com/AlexSkrypnyk/prompty
  *
  * Usage:
- *   php embed.php [--compact] [--no-killswitch] <source>
- *                 [<output>]
- *   php embed.php [--compact] --stdout <output-file>
+ *   php embed.php [options] <source-script> [<output-script>]
+ *   php embed.php [options] --stdout <output-file>
  *
  * The source script must contain // @embed-start and // @embed-end markers.
- * The minified class will be inserted between these markers.
+ * The minified class will be inserted between these markers. Re-running on
+ * a previously embedded script replaces the embedded region with the latest
+ * class content while preserving all other code.
  *
  * If <output-script> is provided, the source is copied there first and the
  * embedding is performed on the copy. Otherwise the source is modified
@@ -26,6 +27,8 @@
  * then run to verify it works.
  *
  * Options:
+ *   --source <path>  Path to the PHP class file to embed. Defaults to
+ *                    Prompty.php in the same directory as this script.
  *   --compact        Apply additional size optimizations: shorten internal
  *                    property and method names, rename local variables,
  *                    reduce whitespace.
@@ -50,6 +53,7 @@ define('EMBED_MARKER_END', '@embed-end');
 $compact = FALSE;
 $stdout = FALSE;
 $no_killswitch = FALSE;
+$source_override = NULL;
 $positional = [];
 
 for ($arg_i = 1; $arg_i < $argc; $arg_i++) {
@@ -62,13 +66,49 @@ for ($arg_i = 1; $arg_i < $argc; $arg_i++) {
   elseif ($argv[$arg_i] === '--no-killswitch') {
     $no_killswitch = TRUE;
   }
+  elseif ($argv[$arg_i] === '--source') {
+    $arg_i++;
+    if ($arg_i >= $argc) {
+      fwrite(STDERR, "Error: --source requires a path argument.\n");
+      exit(1);
+    }
+    $source_override = $argv[$arg_i];
+  }
   else {
     $positional[] = $argv[$arg_i];
   }
 }
 
 if ($positional === []) {
-  fwrite(STDERR, "Usage: php embed.php [--compact] [--no-killswitch] [--stdout] <source-script> [<output-script>]\n");
+  $usage = <<<'USAGE'
+Embedder — minifies and embeds a PHP class into a target script.
+
+Usage:
+  php embed.php [options] <source-script> [<output-script>]
+  php embed.php [options] --stdout <output-file>
+
+Arguments:
+  <source-script>   Script containing // @embed-start and // @embed-end markers.
+                    Modified in place unless <output-script> is provided.
+  <output-script>   Optional output path. Source is copied here before embedding.
+
+Options:
+  --source <path>   Path to the PHP class file to embed. Defaults to Prompty.php
+                    in the same directory as this script.
+  --compact         Shorten internal property/method names, rename local
+                    variables, and reduce whitespace for a smaller output.
+  --stdout          Output the processed class as a standalone PHP file instead
+                    of embedding into a target script.
+  --no-killswitch   Skip injecting the kill-switch block and post-embed
+                    verification run.
+
+Re-embedding:
+  Running embed.php on a previously embedded script replaces the embedded region
+  with the latest class content. All code outside the markers is preserved. Use
+  --source to point at an updated Prompty.php for version updates.
+
+USAGE;
+  fwrite(STDERR, $usage);
   exit(1);
 }
 
@@ -93,16 +133,18 @@ else {
   }
 }
 
-if (!is_file(EMBED_SOURCE)) {
-  fwrite(STDERR, sprintf('Error: Source class not found: %s%s', EMBED_SOURCE, PHP_EOL));
+$embed_source = $source_override ?? EMBED_SOURCE;
+
+if (!is_file($embed_source)) {
+  fwrite(STDERR, sprintf('Error: Source class not found: %s%s', $embed_source, PHP_EOL));
   exit(1);
 }
 
 // Read and tokenize the source class.
-$source = file_get_contents(EMBED_SOURCE);
+$source = file_get_contents($embed_source);
 
 if ($source === FALSE) {
-  fwrite(STDERR, sprintf('Error: Could not read source class: %s%s', EMBED_SOURCE, PHP_EOL));
+  fwrite(STDERR, sprintf('Error: Could not read source class: %s%s', $embed_source, PHP_EOL));
   exit(1);
 }
 

--- a/tests/phpunit/Unit/EmbedScriptTest.php
+++ b/tests/phpunit/Unit/EmbedScriptTest.php
@@ -417,6 +417,162 @@ final class EmbedScriptTest extends TestCase {
     $this->assertStringContainsString('no kill switch', strtolower($embed_output));
   }
 
+  public function testSourceFlag(): void {
+    $target = $this->prepareTarget();
+
+    // Copy Prompty.php to a different location.
+    $alt_source = $this->tmpDir . '/AltPrompty.php';
+    copy(__DIR__ . '/../../../Prompty.php', $alt_source);
+
+    $this->runEmbed($target, ['--source', $alt_source]);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+
+    // Class embedded from the alternate source.
+    $this->assertStringContainsString('// @embed-start', $content);
+    $this->assertStringContainsString('// @embed-end', $content);
+    $this->assertStringContainsString('class Prompty', $content);
+    $this->assertStringNotContainsString('require_once', $content);
+
+    // Embedded script runs correctly.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
+  public function testSourceFlagStdout(): void {
+    $output_path = $this->tmpDir . '/Prompty.source.php';
+
+    // Copy Prompty.php to a different location.
+    $alt_source = $this->tmpDir . '/AltPrompty.php';
+    copy(__DIR__ . '/../../../Prompty.php', $alt_source);
+
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $cmd_output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --source ' . escapeshellarg($alt_source) . ' --stdout ' . escapeshellarg($output_path) . ' 2>&1', $cmd_output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Embed --source --stdout failed: ' . implode("\n", $cmd_output));
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($output_path) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    $content = file_get_contents($output_path);
+    $this->assertIsString($content);
+    $this->assertStringContainsString('class Prompty', $content);
+    $this->assertStringContainsString('namespace AlexSkrypnyk\Prompty', $content);
+  }
+
+  public function testReEmbedPreservesContentAndWorks(): void {
+    $target = $this->prepareTarget();
+
+    // First embed.
+    $this->runEmbed($target);
+    $first_content = file_get_contents($target);
+    $this->assertIsString($first_content);
+    $this->assertStringContainsString('class Prompty', $first_content);
+    $this->assertStringNotContainsString('require_once', $first_content);
+
+    // Verify the first embed works.
+    $this->assertEmbeddedScriptWorks($target);
+
+    // Simulate a user editing the script outside the embedded block.
+    $modified = str_replace(
+      "intro: 'Create a new project'",
+      "intro: 'Create a NEW project'",
+      $first_content,
+    );
+    $this->assertNotSame($first_content, $modified);
+    file_put_contents($target, $modified);
+
+    // Re-embed (simulating a version update).
+    $this->runEmbed($target);
+    $re_embedded = file_get_contents($target);
+    $this->assertIsString($re_embedded);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed after re-embed: ' . implode("\n", $lint_output));
+
+    // User's edit preserved.
+    $this->assertStringContainsString("intro: 'Create a NEW project'", $re_embedded);
+
+    // Markers still present.
+    $this->assertStringContainsString('// @embed-start', $re_embedded);
+    $this->assertStringContainsString('// @embed-end', $re_embedded);
+
+    // Class still embedded.
+    $this->assertStringContainsString('class Prompty', $re_embedded);
+    $this->assertStringNotContainsString('require_once', $re_embedded);
+
+    // Kill switch not duplicated.
+    $this->assertSame(
+      1,
+      substr_count($re_embedded, "if (!getenv('SHOULD_PROCEED'))"),
+      'Kill switch should appear exactly once after re-embed.',
+    );
+
+    // Embedded script still runs correctly after re-embed.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
+  public function testReEmbedWithSourceFlag(): void {
+    $target = $this->prepareTarget();
+
+    // First embed with default source.
+    $this->runEmbed($target);
+
+    // Copy Prompty.php to simulate downloading a new version.
+    $new_version = $this->tmpDir . '/PromptyNew.php';
+    copy(__DIR__ . '/../../../Prompty.php', $new_version);
+
+    // Re-embed with --source pointing at the "new version".
+    $this->runEmbed($target, ['--source', $new_version]);
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    // Class embedded, markers preserved.
+    $this->assertStringContainsString('class Prompty', $content);
+    $this->assertStringContainsString('// @embed-start', $content);
+    $this->assertStringContainsString('// @embed-end', $content);
+
+    // Embedded script works.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
+  public function testUsageHelp(): void {
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg(__DIR__ . '/../../../embed.php') . ' 2>&1', $output, $exit_code);
+    $this->assertSame(1, $exit_code);
+
+    $help = implode("\n", $output);
+
+    // Usage header present.
+    $this->assertStringContainsString('Usage:', $help);
+
+    // All flags documented.
+    $this->assertStringContainsString('--source', $help);
+    $this->assertStringContainsString('--compact', $help);
+    $this->assertStringContainsString('--stdout', $help);
+    $this->assertStringContainsString('--no-killswitch', $help);
+
+    // Re-embedding documented.
+    $this->assertStringContainsString('Re-embedding', $help);
+
+    // Arguments section present.
+    $this->assertStringContainsString('Arguments:', $help);
+    $this->assertStringContainsString('Options:', $help);
+  }
+
   public function testEmbedErrors(): void {
     // Missing argument.
     $output = [];
@@ -434,6 +590,21 @@ final class EmbedScriptTest extends TestCase {
     exec('php ' . escapeshellarg(__DIR__ . '/../../../embed.php') . ' ' . escapeshellarg($target) . ' 2>&1', $output, $exit_code);
     $this->assertSame(1, $exit_code);
     $this->assertStringContainsString('marker', implode("\n", $output));
+
+    // --source without path.
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg(__DIR__ . '/../../../embed.php') . ' --source 2>&1', $output, $exit_code);
+    $this->assertSame(1, $exit_code);
+    $this->assertStringContainsString('--source requires a path', implode("\n", $output));
+
+    // --source with non-existent file.
+    $target = $this->prepareTarget();
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg(__DIR__ . '/../../../embed.php') . ' --source /nonexistent/Prompty.php ' . escapeshellarg($target) . ' 2>&1', $output, $exit_code);
+    $this->assertSame(1, $exit_code);
+    $this->assertStringContainsString('Source class not found', implode("\n", $output));
   }
 
   /**

--- a/tests/phpunit/Unit/EmbedScriptTest.php
+++ b/tests/phpunit/Unit/EmbedScriptTest.php
@@ -548,6 +548,86 @@ final class EmbedScriptTest extends TestCase {
     $this->assertEmbeddedScriptWorks($target);
   }
 
+  public function testSourceFlagWithMinifiedInput(): void {
+    $target = $this->prepareTarget();
+
+    // Generate a minified Prompty.php via --stdout.
+    $min_source = $this->tmpDir . '/Prompty.min.php';
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --stdout ' . escapeshellarg($min_source) . ' 2>&1', $output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Failed to generate minified source: ' . implode("\n", $output));
+
+    // Embed using the already-minified file as source.
+    $this->runEmbed($target, ['--source', $min_source]);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+    $this->assertStringContainsString('class Prompty', $content);
+    $this->assertStringContainsString('// @embed-start', $content);
+
+    // Embedded script runs correctly.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
+  public function testSourceFlagWithCompactedInput(): void {
+    $target = $this->prepareTarget();
+
+    // Generate a compacted Prompty.php via --compact --stdout.
+    $compact_source = $this->tmpDir . '/Prompty.compact.php';
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --compact --stdout ' . escapeshellarg($compact_source) . ' 2>&1', $output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Failed to generate compacted source: ' . implode("\n", $output));
+
+    // Embed using the already-compacted file as source.
+    $this->runEmbed($target, ['--source', $compact_source]);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+    $this->assertStringContainsString('class Prompty', $content);
+    $this->assertStringContainsString('// @embed-start', $content);
+
+    // Embedded script runs correctly.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
+  public function testSourceFlagWithCompactedInputAndCompactFlag(): void {
+    $target = $this->prepareTarget();
+
+    // Generate a compacted Prompty.php via --compact --stdout.
+    $compact_source = $this->tmpDir . '/Prompty.compact.php';
+    $embed_script = __DIR__ . '/../../../embed.php';
+    $output = [];
+    $exit_code = 0;
+    exec('php ' . escapeshellarg($embed_script) . ' --compact --stdout ' . escapeshellarg($compact_source) . ' 2>&1', $output, $exit_code);
+    $this->assertSame(0, $exit_code, 'Failed to generate compacted source: ' . implode("\n", $output));
+
+    // Embed with --compact using an already-compacted source (double compact).
+    $this->runEmbed($target, ['--source', $compact_source, '--compact']);
+
+    // PHP lint passes.
+    exec('php -l ' . escapeshellarg($target) . ' 2>&1', $lint_output, $lint_exit);
+    $this->assertSame(0, $lint_exit, 'PHP lint failed: ' . implode("\n", $lint_output));
+
+    $content = file_get_contents($target);
+    $this->assertIsString($content);
+    $this->assertStringContainsString('class Prompty', $content);
+
+    // Embedded script runs correctly even after double compaction.
+    $this->assertEmbeddedScriptWorks($target);
+  }
+
   public function testUsageHelp(): void {
     $output = [];
     $exit_code = 0;


### PR DESCRIPTION
Closes #12

## Summary

Added a `--source` flag to `embed.php` that lets callers specify an alternative path to the PHP class file to embed, rather than always defaulting to `Prompty.php` alongside the script. Alongside this, the embedder now fully supports re-embedding: running it on a script that already contains an embedded region replaces only that region with the latest class content, leaving all other code untouched. Documentation and tests were updated accordingly, and the usage/help output was expanded to cover all options and the re-embedding workflow.

## Changes

### `embed.php` — embedder script
- Added `--source <path>` CLI option with argument validation (error if flag is passed without a value or if the path does not exist).
- Expanded the no-arguments usage message into a full help block covering `Arguments:`, `Options:`, and a `Re-embedding:` section.
- Replaced hardcoded `EMBED_SOURCE` references with `$embed_source = $source_override ?? EMBED_SOURCE` so the new flag is honoured throughout.
- Updated the doc-comment header to reflect the revised usage syntax.

### `README.md` — documentation
- Added `--source` flag documentation under the embedding section.
- Added a "Re-embedding" subsection explaining how to update an already-embedded script.
- Added a collapsible "For AI agents" section with step-by-step `curl` + `embed.php` recipes for: embedding into the starter script, embedding into a custom script, and updating Prompty to a newer version.

### `tests/phpunit/Unit/EmbedScriptTest.php` — test coverage
- `testSourceFlag` — embeds using `--source` pointing to an alternate file path.
- `testSourceFlagStdout` — combines `--source` with `--stdout`.
- `testReEmbedPreservesContentAndWorks` — verifies a second embed replaces the embedded region, preserves user edits outside markers, does not duplicate the kill switch, and produces a working script.
- `testReEmbedWithSourceFlag` — re-embed using `--source` for a simulated version update.
- `testSourceFlagWithMinifiedInput` — uses a previously minified class file as the `--source`.
- `testSourceFlagWithCompactedInput` — uses a previously compacted class file as the `--source`.
- `testSourceFlagWithCompactedInputAndCompactFlag` — double-compaction path (compacted source + `--compact` flag).
- `testUsageHelp` — asserts the help output contains all flags, sections, and the Re-embedding heading.
- Extended `testEmbedErrors` — covers `--source` without a path and `--source` with a non-existent file.

## Before / After

```
Before: embed.php source resolution
┌─────────────────────────────────────────────────┐
│  embed.php                                      │
│                                                 │
│  class source: EMBED_SOURCE (constant)          │
│  = __DIR__ . '/Prompty.php'  (always)           │
│                                                 │
│  re-embed: no explicit support                  │
│  (markers already present → undefined result)  │
└─────────────────────────────────────────────────┘

After: embed.php source resolution
┌─────────────────────────────────────────────────┐
│  embed.php                                      │
│                                                 │
│  --source <path> ──┐                            │
│                    ▼                            │
│  $embed_source = $source_override               │
│                  ?? EMBED_SOURCE                │
│                                                 │
│  re-embed: supported — existing embedded region │
│  is replaced; all code outside markers kept     │
└─────────────────────────────────────────────────┘

CLI help (before → after)
┌──────────────────────────────────┐   ┌────────────────────────────────────────┐
│ Usage: php embed.php [--compact] │   │ Embedder — minifies and embeds a PHP   │
│   [--no-killswitch] [--stdout]   │   │ class into a target script.            │
│   <source-script> [<output>]     │   │                                        │
│                                  │   │ Usage: / Arguments: / Options:         │
│ (single line)                    │   │ --source, --compact, --stdout,         │
│                                  │   │ --no-killswitch documented             │
└──────────────────────────────────┘   │ Re-embedding: section included         │
                                       └────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements support for the `--source` flag in `embed.php` and adds re-embedding capability, addressing #12.

### Key Changes

**embed.php:**
- Added `--source <path>` CLI flag to specify an alternative path to the PHP class file for embedding (default remains `EMBED_SOURCE` / `Prompty.php`)
- Includes validation for the flag (errors when path is missing or file doesn't exist)
- Updated CLI usage/help text to display arguments, options, and re-embedding information
- Modified source file resolution to use the specified `$embed_source` path

**Re-embedding Support:**
- The embedder now preserves all code outside the `// @embed-start` and `// @embed-end` markers when re-embedding
- Re-embedding replaces only the marked region with updated class content
- The kill-switch is not duplicated on subsequent runs
- Supports combining `--source` with re-embedding to update already-embedded scripts with a different class version

**Documentation (README.md):**
- Added `--source` flag documentation
- Introduced "Re-embedding" section explaining how to refresh an already-embedded script
- Added "For AI agents" collapsible section with curl and embed.php recipes for:
  - Embedding into starter templates
  - Embedding into custom scripts (with required marker placement)
  - Updating Prompty versions

**Tests (tests/phpunit/Unit/EmbedScriptTest.php):**
- New test methods covering `--source` flag functionality and combinations with `--stdout` and `--compact`
- Re-embed behavior tests validating preservation of external edits and prevention of kill-switch duplication
- Re-embed with `--source` scenarios for simulating version updates
- Tests for handling minified/compacted source inputs
- Usage/help output validation confirming all flags and re-embedding documentation are present
- Error case tests for missing `--source` path and non-existent files

### Files Modified
- `embed.php` (+51/-9 lines)
- `README.md` (+82/-0 lines)
- `tests/phpunit/Unit/EmbedScriptTest.php` (+251/-0 lines)

### Related Issue
Closes #12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->