### PR TITLE
Adopted 'alexskrypnyk/phpunit-helpers' for functional tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=8.2"
     },
     "require-dev": {
+        "alexskrypnyk/phpunit-helpers": "^0.16.0",
         "bamarni/composer-bin-plugin": "^1.8",
         "dealerdirect/phpcodesniffer-composer-installer": "^1",
         "drevops/phpcs-standard": "^0.6",

--- a/tests/phpunit/Functional/EmbedScriptTest.php
+++ b/tests/phpunit/Functional/EmbedScriptTest.php
@@ -93,8 +93,8 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->assertStringNotContainsString('renderCancelled', $content);
 
     // Compact output is smaller than normal.
-    $normal_target = $this->tmpDir . '/normal.php';
-    copy($this->root . '/starter.php', $normal_target);
+    $normal_target = self::$tmp . '/normal.php';
+    copy(self::$root . '/starter.php', $normal_target);
     $this->runEmbed($normal_target);
     $this->assertLessThan(filesize($normal_target), filesize($target));
 
@@ -104,7 +104,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
 
   public function testEmbedWithOutputArgument(): void {
     $source = $this->prepareTarget();
-    $output_path = $this->tmpDir . '/output.php';
+    $output_path = self::$tmp . '/output.php';
 
     $this->runEmbed($source, $output_path);
 
@@ -192,7 +192,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
 
     // Smaller than original.
     $this->assertLessThan(
-      filesize($this->root . '/Prompty.php'),
+      filesize(self::$root . '/Prompty.php'),
       filesize($output_path),
     );
   }
@@ -273,13 +273,13 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $target = $this->prepareTarget();
 
     $keystrokes = $this->keys(
-      'my-project', self::KEY_ENTER,
-      self::KEY_DOWN, self::KEY_ENTER,
-      self::KEY_SPACE, self::KEY_ENTER,
-      self::KEY_ENTER,
+      'my-project', self::KEYS['ENTER'],
+      self::KEYS['DOWN'], self::KEYS['ENTER'],
+      self::KEYS['SPACE'], self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
     );
 
-    $r = $this->runWithKeystrokes('php ' . escapeshellarg($this->root . '/embed.php') . ' ' . escapeshellarg($target), $keystrokes);
+    $r = $this->runWithKeystrokes('php ' . escapeshellarg(self::$root . '/embed.php') . ' ' . escapeshellarg($target), $keystrokes);
     $this->assertSame(0, $r['exit_code'], 'Embed with verification failed: ' . $r['stderr']);
     $this->assertStringContainsString('Verifying', $r['stdout']);
   }
@@ -317,7 +317,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
   }
 
   public function testSourceFlagStdout(): void {
-    $output_path = $this->tmpDir . '/Prompty.source.php';
+    $output_path = self::$tmp . '/Prompty.source.php';
     $alt_source = $this->copyPromptySource();
 
     $this->runEmbed('--source', $alt_source, '--stdout', $output_path);
@@ -398,43 +398,45 @@ final class EmbedScriptTest extends FunctionalTestCase {
   }
 
   public function testUsageHelp(): void {
-    $r = $this->runEmbedRaw();
-    $this->assertSame(1, $r['exit_code']);
+    $this->processRun('php', [self::$root . '/embed.php']);
+    $this->assertProcessFailed();
 
-    $this->assertStringContainsString('Usage:', $r['output']);
-    $this->assertStringContainsString('--source', $r['output']);
-    $this->assertStringContainsString('--compact', $r['output']);
-    $this->assertStringContainsString('--stdout', $r['output']);
-    $this->assertStringContainsString('--no-killswitch', $r['output']);
-    $this->assertStringContainsString('Re-embedding', $r['output']);
-    $this->assertStringContainsString('Arguments:', $r['output']);
-    $this->assertStringContainsString('Options:', $r['output']);
+    $this->assertProcessAnyOutputContains([
+      'Usage:',
+      '--source',
+      '--compact',
+      '--stdout',
+      '--no-killswitch',
+      'Re-embedding',
+      'Arguments:',
+      'Options:',
+    ]);
   }
 
   public function testEmbedErrors(): void {
     // Missing argument.
-    $r = $this->runEmbedRaw();
-    $this->assertSame(1, $r['exit_code']);
-    $this->assertStringContainsString('Usage', $r['output']);
+    $this->processRun('php', [self::$root . '/embed.php']);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('Usage');
 
     // Missing markers.
-    $target = $this->tmpDir . '/no-markers.php';
+    $target = self::$tmp . '/no-markers.php';
     file_put_contents($target, "<?php\necho 'hello';\n");
 
-    $r = $this->runEmbedRaw($target);
-    $this->assertSame(1, $r['exit_code']);
-    $this->assertStringContainsString('marker', $r['output']);
+    $this->processRun('php', [self::$root . '/embed.php', $target]);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('marker');
 
     // --source without path.
-    $r = $this->runEmbedRaw('--source');
-    $this->assertSame(1, $r['exit_code']);
-    $this->assertStringContainsString('--source requires a path', $r['output']);
+    $this->processRun('php', [self::$root . '/embed.php', '--source']);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('--source requires a path');
 
     // --source with non-existent file.
     $target = $this->prepareTarget();
-    $r = $this->runEmbedRaw('--source', '/nonexistent/Prompty.php', $target);
-    $this->assertSame(1, $r['exit_code']);
-    $this->assertStringContainsString('Source class not found', $r['output']);
+    $this->processRun('php', [self::$root . '/embed.php', '--source', '/nonexistent/Prompty.php', $target]);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('Source class not found');
   }
 
   public function testVersionAfterImprinting(): void {
@@ -456,10 +458,10 @@ final class EmbedScriptTest extends FunctionalTestCase {
     file_put_contents($target, $content);
 
     $keystrokes = $this->keys(
-      'test', self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
+      'test', self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
     );
 
     $r = $this->runWithKeystrokes('php ' . escapeshellarg($target), $keystrokes);
@@ -471,8 +473,8 @@ final class EmbedScriptTest extends FunctionalTestCase {
    * Copy starter.php to temp dir and return the path.
    */
   protected function prepareTarget(): string {
-    $target = $this->tmpDir . '/starter.php';
-    copy($this->root . '/starter.php', $target);
+    $target = self::$tmp . '/starter.php';
+    copy(self::$root . '/starter.php', $target);
 
     return $target;
   }
@@ -481,7 +483,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
    * Copy starter.php to temp dir without the kill switch block.
    */
   protected function prepareTargetWithoutKillswitch(): string {
-    $content = file_get_contents($this->root . '/starter.php');
+    $content = file_get_contents(self::$root . '/starter.php');
     $this->assertIsString($content);
 
     $content = preg_replace(
@@ -491,7 +493,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
     );
     $this->assertIsString($content);
 
-    $target = $this->tmpDir . '/starter_no_ks.php';
+    $target = self::$tmp . '/starter_no_ks.php';
     file_put_contents($target, $content);
 
     return $target;
@@ -511,39 +513,26 @@ final class EmbedScriptTest extends FunctionalTestCase {
    *   Combined stdout+stderr output.
    */
   protected function runEmbedWithOutput(string ...$args): string {
-    $r = $this->runEmbedRaw(...$args);
-    $this->assertSame(0, $r['exit_code'], 'Embed script failed: ' . $r['output']);
+    $this->processRun('php', array_merge([self::$root . '/embed.php'], $args));
+    $this->assertProcessSuccessful();
 
-    return $r['output'];
+    return $this->processGet()->getOutput() . $this->processGet()->getErrorOutput();
   }
 
   /**
-   * Run embed.php without asserting exit code.
-   *
-   * @return array{output: string, exit_code: int}
-   *   Output and exit code.
+   * Assert that a PHP file passes lint checking.
    */
-  protected function runEmbedRaw(string ...$args): array {
-    $cmd = 'php ' . escapeshellarg($this->root . '/embed.php');
-    foreach ($args as $arg) {
-      $cmd .= ' ' . escapeshellarg($arg);
-    }
-    $output = [];
-    $exit_code = 0;
-    exec($cmd . ' 2>&1', $output, $exit_code);
-
-    return [
-      'output' => implode("\n", $output),
-      'exit_code' => $exit_code,
-    ];
+  protected function assertPhpLintPasses(string $path): void {
+    $this->processRun('php', ['-l', $path]);
+    $this->assertProcessSuccessful('PHP lint failed');
   }
 
   /**
    * Copy Prompty.php to the temp directory.
    */
   protected function copyPromptySource(): string {
-    $path = $this->tmpDir . '/Prompty.php';
-    copy($this->root . '/Prompty.php', $path);
+    $path = self::$tmp . '/Prompty.php';
+    copy(self::$root . '/Prompty.php', $path);
 
     return $path;
   }
@@ -552,7 +541,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
    * Generate a minified Prompty.php via --stdout.
    */
   protected function generateMinified(): string {
-    $path = $this->tmpDir . '/Prompty.min.php';
+    $path = self::$tmp . '/Prompty.min.php';
     $this->runEmbed('--stdout', $path);
 
     return $path;
@@ -562,7 +551,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
    * Generate a compacted Prompty.php via --compact --stdout.
    */
   protected function generateCompacted(): string {
-    $path = $this->tmpDir . '/Prompty.compact.php';
+    $path = self::$tmp . '/Prompty.compact.php';
     $this->runEmbed('--compact', '--stdout', $path);
 
     return $path;
@@ -572,8 +561,8 @@ final class EmbedScriptTest extends FunctionalTestCase {
    * Create a rector config file suitable for testing embedded output.
    */
   protected function createRectorConfig(): string {
-    $config_path = $this->tmpDir . '/rector.php';
-    copy($this->root . '/rector.php', $config_path);
+    $config_path = self::$tmp . '/rector.php';
+    copy(self::$root . '/rector.php', $config_path);
 
     return $config_path;
   }
@@ -583,14 +572,14 @@ final class EmbedScriptTest extends FunctionalTestCase {
    */
   protected function assertRectorClean(string $target): void {
     $rector_config = $this->createRectorConfig();
-    $output = [];
-    $exit_code = 0;
-    exec(
-      'php ' . escapeshellarg($this->root . '/vendor/bin/rector') . ' process --dry-run --config=' . escapeshellarg($rector_config) . ' ' . escapeshellarg($target) . ' 2>&1',
-      $output,
-      $exit_code,
-    );
-    $this->assertSame(0, $exit_code, 'Rector would make further changes: ' . implode("\n", $output));
+    $this->processRun('php', [
+      self::$root . '/vendor/bin/rector',
+      'process',
+      '--dry-run',
+      '--config=' . $rector_config,
+      $target,
+    ]);
+    $this->assertProcessSuccessful('Rector would make further changes');
   }
 
 }

--- a/tests/phpunit/Functional/FunctionalTestCase.php
+++ b/tests/phpunit/Functional/FunctionalTestCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\Prompty\Tests\Functional;
 
+use AlexSkrypnyk\PhpunitHelpers\Traits\LocationsTrait;
+use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
+use AlexSkrypnyk\PhpunitHelpers\Traits\TuiTrait;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
@@ -16,47 +19,25 @@ use PHPUnit\Framework\TestCase;
 #[CoversNothing]
 abstract class FunctionalTestCase extends TestCase {
 
-  protected const KEY_ENTER = "\n";
-  protected const KEY_SPACE = ' ';
-  protected const KEY_BACKSPACE = "\x7f";
-  protected const KEY_TAB = "\t";
-  protected const KEY_ESCAPE = "\x1b";
-  protected const KEY_CTRL_C = "\x03";
-  protected const KEY_UP = "\x1b[A";
-  protected const KEY_DOWN = "\x1b[B";
-  protected const KEY_RIGHT = "\x1b[C";
-  protected const KEY_LEFT = "\x1b[D";
-
-  /**
-   * Project root directory.
-   */
-  protected string $root;
-
-  /**
-   * Temporary directory for test artifacts.
-   */
-  protected string $tmpDir;
+  use LocationsTrait;
+  use ProcessTrait;
+  use TuiTrait;
 
   protected function setUp(): void {
     parent::setUp();
-
-    $this->root = dirname(__DIR__, 3);
-
-    $short_class = (new \ReflectionClass(static::class))->getShortName();
-    $this->tmpDir = $this->root . '/.artifacts/tmp/' . $short_class . '_' . getmypid();
-    mkdir($this->tmpDir, 0755, TRUE);
+    $this->locationsInit();
   }
 
   protected function tearDown(): void {
-    if (is_dir($this->tmpDir)) {
-      $files = glob($this->tmpDir . '/*');
-      if ($files !== FALSE) {
-        array_map(unlink(...), $files);
-      }
-      rmdir($this->tmpDir);
-    }
-
+    $this->locationsTearDown();
     parent::tearDown();
+  }
+
+  /**
+   * Assertion suffix for ProcessTrait error messages.
+   */
+  protected function assertionSuffix(): string {
+    return '';
   }
 
   /**
@@ -67,22 +48,15 @@ abstract class FunctionalTestCase extends TestCase {
   }
 
   /**
-   * Assert that a PHP file passes lint checking.
-   */
-  protected function assertPhpLintPasses(string $path): void {
-    $output = [];
-    $exit_code = 0;
-    exec('php -l ' . escapeshellarg($path) . ' 2>&1', $output, $exit_code);
-    $this->assertSame(0, $exit_code, 'PHP lint failed: ' . implode("\n", $output));
-  }
-
-  /**
-   * Run a command in a subprocess with simulated keystrokes.
+   * Run a command in a subprocess with raw keystroke input.
+   *
+   * Unlike processRun() which joins inputs with newlines, this method
+   * passes raw bytes directly to stdin — required for TUI escape sequences.
    *
    * @param string $command
    *   The command to execute.
    * @param string $keystrokes
-   *   Simulated keyboard input.
+   *   Raw keystroke bytes.
    *
    * @return array{stdout: string, stderr: string, exit_code: int}
    *   Process output.
@@ -140,19 +114,16 @@ abstract class FunctionalTestCase extends TestCase {
    */
   protected function assertStarterFlowWorks(string $script_path): void {
     $keystrokes = $this->keys(
-      'my-project', self::KEY_ENTER,
-      self::KEY_DOWN, self::KEY_ENTER,
-      self::KEY_SPACE, self::KEY_ENTER,
-      self::KEY_ENTER,
+      'my-project', static::KEYS['ENTER'],
+      static::KEYS['DOWN'], static::KEYS['ENTER'],
+      static::KEYS['SPACE'], static::KEYS['ENTER'],
+      static::KEYS['ENTER'],
     );
 
     $output = $this->runScript($script_path, $keystrokes);
 
-    // Intro and outro.
     $this->assertStringContainsString('Create a new project', $output);
     $this->assertStringContainsString('Project created!', $output);
-
-    // Completed values.
     $this->assertStringContainsString('my-project', $output);
     $this->assertStringContainsString('Vue', $output);
     $this->assertStringContainsString('TypeScript', $output);

--- a/tests/phpunit/Functional/StarterScriptTest.php
+++ b/tests/phpunit/Functional/StarterScriptTest.php
@@ -24,7 +24,7 @@ final class StarterScriptTest extends FunctionalTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->starterScript = $this->root . '/starter.php';
+    $this->starterScript = self::$root . '/starter.php';
   }
 
   public function testStarterFlowCompletes(): void {
@@ -33,10 +33,10 @@ final class StarterScriptTest extends FunctionalTestCase {
 
   public function testStarterSelectThirdFramework(): void {
     $keystrokes = $this->keys(
-      'app', self::KEY_ENTER,
-      self::KEY_DOWN, self::KEY_DOWN, self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
+      'app', self::KEYS['ENTER'],
+      self::KEYS['DOWN'], self::KEYS['DOWN'], self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
     );
 
     $output = $this->runScript($this->starterScript, $keystrokes);
@@ -49,10 +49,10 @@ final class StarterScriptTest extends FunctionalTestCase {
 
   public function testStarterEmptyNameUsesPlaceholder(): void {
     $keystrokes = $this->keys(
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
     );
 
     $output = $this->runScript($this->starterScript, $keystrokes);
@@ -63,10 +63,10 @@ final class StarterScriptTest extends FunctionalTestCase {
 
   public function testStarterDeclineInstall(): void {
     $keystrokes = $this->keys(
-      'test', self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_LEFT, self::KEY_ENTER,
+      'test', self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['LEFT'], self::KEYS['ENTER'],
     );
 
     $output = $this->runScript($this->starterScript, $keystrokes);
@@ -77,10 +77,10 @@ final class StarterScriptTest extends FunctionalTestCase {
 
   public function testStarterOutputContainsIntroOutro(): void {
     $keystrokes = $this->keys(
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
-      self::KEY_ENTER,
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
+      self::KEYS['ENTER'],
     );
 
     $output = $this->runScript($this->starterScript, $keystrokes);


### PR DESCRIPTION
## Summary

Replaced the custom functional test infrastructure in `FunctionalTestCase` with the `alexskrypnyk/phpunit-helpers` package, which provides reusable traits for process execution, TUI (terminal UI) interaction, and filesystem location management. This removes hand-rolled equivalents (`exec()`-based helpers, manually managed temp directories, and hard-coded key constants) in favour of well-tested library implementations. All three functional test classes (`EmbedScriptTest`, `StarterScriptTest`, and the base `FunctionalTestCase`) were updated accordingly.

## Changes

### Dependency (`composer.json`)
- Added `alexskrypnyk/phpunit-helpers ^0.16.0` as a dev dependency.

### Base test case (`tests/phpunit/Functional/FunctionalTestCase.php`)
- Replaced manual `$root` / `$tmpDir` instance properties and their setup/teardown logic with `LocationsTrait` (provides `self::$root` and `self::$tmp` as static properties, plus `locationsInit()` / `locationsTearDown()`).
- Removed hand-coded `KEY_*` constants in favour of `TuiTrait::KEYS[...]` array provided by `TuiTrait`.
- Replaced the bespoke `exec()`-based `assertPhpLintPasses()` with `ProcessTrait::processRun()` + `assertProcessSuccessful()` (moved into `EmbedScriptTest`).
- Replaced `runEmbedRaw()` (returning an ad-hoc array) with `processRun()` + dedicated assertion helpers.
- Added `assertionSuffix()` stub required by `ProcessTrait`.

### Embed script tests (`tests/phpunit/Functional/EmbedScriptTest.php`)
- Updated all references from `$this->tmpDir` → `self::$tmp` and `$this->root` → `self::$root`.
- Replaced `self::KEY_*` with `self::KEYS[...]`.
- Converted `testUsageHelp()` and `testEmbedErrors()` to use `processRun()` + `assertProcessFailed()` / `assertProcessAnyOutputContains()`.
- Replaced the `exec()`-based `assertRectorClean()` helper with `processRun()`.
- Removed `runEmbedRaw()` method entirely; updated `runEmbedWithOutput()` to use `processRun()` internally.

### Starter script tests (`tests/phpunit/Functional/StarterScriptTest.php`)
- Updated `$this->root` → `self::$root`.
- Replaced `self::KEY_*` with `self::KEYS[...]` throughout.

## Before / After

```
Before
──────────────────────────────────────────────────────
FunctionalTestCase
├── KEY_ENTER, KEY_DOWN, KEY_SPACE ... (10 constants)
├── $root (instance property, set in setUp)
├── $tmpDir (instance property, mkdir/rmdir in setUp/tearDown)
├── assertPhpLintPasses() — exec('php -l ...')
└── (no process abstraction)

EmbedScriptTest
├── runEmbedRaw() — exec('php embed.php ...') → array{output, exit_code}
└── runEmbedWithOutput() — wraps runEmbedRaw(), asserts exit=0

After
──────────────────────────────────────────────────────
FunctionalTestCase
├── use LocationsTrait  → self::$root, self::$tmp, lifecycle hooks
├── use ProcessTrait    → processRun(), assertProcessSuccessful/Failed(),
│                         assertProcessAnyOutputContains()
└── use TuiTrait        → KEYS['ENTER'], KEYS['DOWN'], KEYS['SPACE'] ...

EmbedScriptTest
├── assertPhpLintPasses() — processRun('php', ['-l', $path])
└── runEmbedWithOutput()  — processRun('php', ['embed.php', ...])
    (runEmbedRaw() removed)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary

This pull request adopts the `alexskrypnyk/phpunit-helpers` package (v^0.16.0) to replace the repository's custom functional test infrastructure, centralizing process execution, TUI interaction, and filesystem location management.

## Changes

### Dependencies
- **composer.json**: Added `alexskrypnyk/phpunit-helpers` ^0.16.0 as a development dependency.

### Test Infrastructure Refactoring

**FunctionalTestCase.php** (base test class):
- Removed manual properties and lifecycle management for `$root` and `$tmpDir`; now delegates to `LocationsTrait` (provides `self::$root`, `self::$tmp`, and lifecycle hooks)
- Removed custom keystroke constants (`KEY_ENTER`, `KEY_SPACE`, `KEY_BACKSPACE`, `KEY_TAB`, `KEY_ESCAPE`, `KEY_CTRL_C`, `KEY_UP`, `KEY_DOWN`, `KEY_RIGHT`, `KEY_LEFT`)
- Removed `assertPhpLintPasses()` in favor of `ProcessTrait::processRun()`
- Replaced `runEmbedRaw()` with `ProcessTrait::processRun()` and assertion helpers
- Added `assertionSuffix()` stub required by `ProcessTrait`
- Composed `LocationsTrait`, `ProcessTrait`, and `TuiTrait` from phpunit-helpers
- Keystroke generation updated to use `static::KEYS[...]` from `TuiTrait`

**EmbedScriptTest.php**:
- Updated filesystem references from `$this->tmpDir`/`$this->root` to `self::$tmp`/`self::$root`
- Replaced keystroke constants with `self::KEYS[...]` indexed access
- Converted test execution to use `processRun()` with `assertProcessFailed()`, `assertProcessSuccessful()`, and `assertProcessAnyOutputContains()`
- Updated `runEmbedWithOutput()` to use `processRun()` and retrieve output via `processGet()->getOutput()/getErrorOutput()`
- Replaced `assertPhpLintPasses()` call with `processRun()` executing `php -l`
- Removed `runEmbedRaw()` helper method

**StarterScriptTest.php**:
- Updated filesystem references from `$this->root` to `self::$root`
- Replaced keystroke constants with `self::KEYS[...]` indexed access

## Impact

- **Reduced code duplication**: Centralizes common test patterns onto the phpunit-helpers library
- **Improved maintainability**: Removes hand-rolled process execution and filesystem management
- **Consistent testing patterns**: Standardizes process assertion helpers across functional tests

## Possibly related to
- #19 — Improved test structure with shared helpers and functional test separation (immediate predecessor work)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->