### PR TITLE
[#21] Added 'default' parameter to 'text', 'select', and 'multiselect' widgets.

### DIFF
--- a/Prompty.php
+++ b/Prompty.php
@@ -877,7 +877,7 @@ class Prompty {
 
     // Interactive multi-selection loop.
     $focused = 0;
-    $checked = array_map(static fn($key): bool => in_array($key, $default, TRUE), $option_keys);
+    $checked = array_map(static fn(string $key): bool => in_array($key, $default, TRUE), $option_keys);
     $line_count = $p->printLines($render_active($focused, $checked));
 
     while (TRUE) {

--- a/Prompty.php
+++ b/Prompty.php
@@ -455,6 +455,8 @@ class Prompty {
    *
    * @param string $label
    *   The widget label shown to the user.
+   * @param string $default
+   *   Pre-filled, editable initial value seeded into the input buffer.
    * @param string $placeholder
    *   Placeholder text shown when the input is empty.
    * @param string $description
@@ -471,10 +473,10 @@ class Prompty {
    * @return \Closure|array<string, mixed>|string|null
    *   A closure in flow mode, or the entered string in standalone mode.
    */
-  public static function text(string $label, string $placeholder = '', string $description = '', mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|string|null {
+  public static function text(string $label, string $default = '', string $placeholder = '', string $description = '', mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|string|null {
     // Flow mode: return closure for deferred execution.
     if (static::$inFlow && $ctx === NULL) {
-      $call = fn(array $ctx): array|\Closure|string|null => static::text($label, placeholder: $placeholder, description: $description, discovered: $discovered, ctx: $ctx);
+      $call = fn(array $ctx): array|\Closure|string|null => static::text($label, default: $default, placeholder: $placeholder, description: $description, discovered: $discovered, ctx: $ctx);
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
@@ -542,7 +544,7 @@ class Prompty {
     };
 
     // Interactive input loop.
-    $value = '';
+    $value = $default;
     $line_count = $p->printLines($render_active($value));
 
     while (TRUE) {
@@ -593,6 +595,8 @@ class Prompty {
    *   The widget label shown to the user.
    * @param array<string, string> $options
    *   Map of option key to display label.
+   * @param string $default
+   *   Option key to focus initially; falls back to the first option.
    * @param string $description
    *   Optional description rendered below the label.
    * @param array<string, string> $hints
@@ -609,9 +613,9 @@ class Prompty {
    * @return \Closure|array<string, mixed>|string|null
    *   A closure in flow mode, or the selected option key in standalone mode.
    */
-  public static function select(string $label, array $options = [], string $description = '', array $hints = [], mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|string|null {
+  public static function select(string $label, array $options = [], string $default = '', string $description = '', array $hints = [], mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|string|null {
     if (static::$inFlow && $ctx === NULL) {
-      $call = fn(array $ctx): array|\Closure|string|null => static::select($label, options: $options, description: $description, hints: $hints, discovered: $discovered, ctx: $ctx);
+      $call = fn(array $ctx): array|\Closure|string|null => static::select($label, options: $options, default: $default, description: $description, hints: $hints, discovered: $discovered, ctx: $ctx);
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
@@ -705,6 +709,12 @@ class Prompty {
 
     // Interactive selection loop.
     $focused = 0;
+    $default_index = $default !== '' ? array_search($default, $option_keys, TRUE) : FALSE;
+
+    if ($default_index !== FALSE) {
+      $focused = (int) $default_index;
+    }
+
     $line_count = $p->printLines($render_active($focused));
 
     while (TRUE) {
@@ -748,6 +758,8 @@ class Prompty {
    *   The widget label shown to the user.
    * @param array<string, string> $options
    *   Map of option key to display label.
+   * @param list<string> $default
+   *   Option keys to pre-check when the widget is rendered interactively.
    * @param string $description
    *   Optional description rendered below the label.
    * @param array<string, string> $hints
@@ -764,9 +776,9 @@ class Prompty {
    * @return \Closure|array<string, mixed>|list<string>|null
    *   A closure in flow mode, or the array of selected keys in standalone mode.
    */
-  public static function multiselect(string $label, array $options = [], string $description = '', array $hints = [], mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|null {
+  public static function multiselect(string $label, array $options = [], array $default = [], string $description = '', array $hints = [], mixed $discovered = NULL, ?callable $condition = NULL, array $children = [], ?array $ctx = NULL): \Closure|array|null {
     if (static::$inFlow && $ctx === NULL) {
-      $call = fn(array $ctx): array|\Closure|null => static::multiselect($label, options: $options, description: $description, hints: $hints, discovered: $discovered, ctx: $ctx);
+      $call = fn(array $ctx): array|\Closure|null => static::multiselect($label, options: $options, default: $default, description: $description, hints: $hints, discovered: $discovered, ctx: $ctx);
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
@@ -865,7 +877,7 @@ class Prompty {
 
     // Interactive multi-selection loop.
     $focused = 0;
-    $checked = array_fill(0, count($option_labels), FALSE);
+    $checked = array_map(static fn($key): bool => in_array($key, $default, TRUE), $option_keys);
     $line_count = $p->printLines($render_active($focused, $checked));
 
     while (TRUE) {

--- a/README.md
+++ b/README.md
@@ -93,14 +93,18 @@ answer, or `null` if they cancel (Escape or Ctrl+C).
 
 ### Text
 
-Free-form text input with an optional placeholder.
+Free-form text input with an optional editable `default` and placeholder.
 
 ```php
 $name = Prompty::text('Project name',
-  placeholder: 'my-app',
+  default: 'my-app',
+  placeholder: 'e.g. my-app',
   description: "Used as the directory name\nand the package name.",
 );
 ```
+
+`default` pre-fills the input with an editable value; `placeholder` is the gray
+hint shown only while the input is empty.
 
 <table>
   <tr>
@@ -122,11 +126,13 @@ $name = Prompty::text('Project name',
 
 ### Select
 
-Single-choice from a list. Arrow keys to navigate, Enter to confirm.
+Single-choice from a list. Arrow keys to navigate, Enter to confirm. Pass
+`default` (an option key) to focus an option other than the first.
 
 ```php
 $framework = Prompty::select('Framework',
   options: ['react' => 'React', 'vue' => 'Vue', 'svelte' => 'Svelte'],
+  default: 'vue',
   description: 'The UI layer for your project.',
   hints: [
     'react' => 'Component-based library by Meta.',
@@ -156,11 +162,14 @@ $framework = Prompty::select('Framework',
 
 ### Multiselect
 
-Multiple-choice from a list. Space to toggle, Enter to confirm.
+Multiple-choice from a list. Space to toggle, Enter to confirm. Pass `default`
+(a list of option keys) to pre-check options - ideal for opt-out lists where
+every option starts selected and the user unchecks what they don't want.
 
 ```php
 $features = Prompty::multiselect('Features',
   options: ['ts' => 'TypeScript', 'eslint' => 'ESLint', 'prettier' => 'Prettier'],
+  default: ['ts', 'eslint', 'prettier'],
   description: "Space to toggle, enter to confirm.",
 );
 ```
@@ -340,6 +349,31 @@ Prompty::select('Framework',
 
 Hints support multi-line text. They appear below the option list and change
 as the user moves between options.
+
+## Default values
+
+Every interactive widget can seed its starting state with `default`, so the user
+begins from a sensible answer and adjusts from there:
+
+| Widget        | `default` type        | Effect                                     |
+|---------------|-----------------------|--------------------------------------------|
+| `text`        | `string`              | Pre-fills the editable input buffer.       |
+| `select`      | `string` (option key) | Focuses that option instead of the first.  |
+| `multiselect` | `list<string>` (keys) | Pre-checks those options.                  |
+| `confirm`     | `bool`                | Starts on Yes (`true`) or No (`false`).    |
+
+```php
+// Opt-out list: everything starts checked; the user unchecks what to drop.
+$keep = Prompty::multiselect('Tools', options: [
+  'phpcs' => 'PHPCS',
+  'phpstan' => 'PHPStan',
+  'eslint' => 'ESLint',
+], default: ['phpcs', 'phpstan', 'eslint']);
+```
+
+`default` only seeds the *interactive* starting state. A value supplied via
+`discovered` or a `PROMPTY_*` environment variable still takes precedence and
+skips the prompt entirely, so explicit input always wins over the default.
 
 ## Unicode and ASCII
 

--- a/playground/widget-multiselect.php
+++ b/playground/widget-multiselect.php
@@ -42,3 +42,11 @@ $r = Prompty::multiselect('Integrations', options: [
   'cdn' => 'Static asset delivery via edge network.',
 ]);
 echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+
+echo "\n--- Multiselect: opt-out (pre-checked default) ---\n";
+$r = Prompty::multiselect('Dev tools', options: [
+  'phpcs' => 'PHPCS',
+  'phpstan' => 'PHPStan',
+  'rector' => 'Rector',
+], default: ['phpcs', 'phpstan', 'rector'], description: 'All selected; uncheck to remove.');
+echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";

--- a/playground/widget-select.php
+++ b/playground/widget-select.php
@@ -42,3 +42,11 @@ $r = Prompty::select('License', options: [
   'gpl3' => "Copyleft. Derivative works must also be GPL.\nStrong open-source guarantee.",
 ]);
 echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+
+echo "\n--- Select: with default (pre-focused) ---\n";
+$r = Prompty::select('Framework', options: [
+  'react' => 'React',
+  'vue' => 'Vue',
+  'svelte' => 'Svelte',
+], default: 'vue', description: 'Vue is focused by default.');
+echo '  Result: ' . ($r ?? 'cancelled') . "\n";

--- a/playground/widget-text.php
+++ b/playground/widget-text.php
@@ -25,3 +25,7 @@ echo '  Result: ' . ($r ?? 'cancelled') . "\n";
 echo "\n--- Text: no placeholder ---\n";
 $r = Prompty::text('Git remote URL');
 echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+
+echo "\n--- Text: with editable default ---\n";
+$r = Prompty::text('Project name', default: 'my-app', description: 'Pre-filled and editable.');
+echo '  Result: ' . ($r ?? 'cancelled') . "\n";

--- a/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
@@ -183,6 +183,16 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
     $this->assertStringContainsString('(cancelled)', (string) $r['output']);
   }
 
+  /**
+   * Tests that pre-checked defaults seed the interactive state.
+   *
+   * @param string $keystrokes
+   *   Raw keystroke bytes to feed.
+   * @param list<string> $default
+   *   Option keys to pre-check.
+   * @param list<string> $expected
+   *   Expected selected option keys.
+   */
   #[DataProvider('dataProviderDefault')]
   public function testDefault(string $keystrokes, array $default, array $expected): void {
     $r = $this->runMultiselectWidget($keystrokes, [], [], [], $default);

--- a/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
@@ -18,12 +18,12 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
   /**
    * Run the multiselect widget with injected keystrokes.
    */
-  protected function runMultiselectWidget(string $keystrokes, array $options = [], array $hints = [], array $ctx_overrides = []): array {
+  protected function runMultiselectWidget(string $keystrokes, array $options = [], array $hints = [], array $ctx_overrides = [], array $default = []): array {
     if ($options === []) {
       $options = ['ts' => 'TypeScript', 'eslint' => 'ESLint', 'prettier' => 'Prettier'];
     }
 
-    return $this->promptyRun(function () use ($options, $hints, $ctx_overrides): mixed {
+    return $this->promptyRun(function () use ($options, $hints, $ctx_overrides, $default): mixed {
       $p = $this->createInstance();
       $default_ctx = [
         'depth' => 0,
@@ -33,7 +33,7 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
         'env_value' => NULL,
       ];
 
-      return Prompty::multiselect('Features', options: $options, hints: $hints, ctx: array_merge($default_ctx, $ctx_overrides));
+      return Prompty::multiselect('Features', options: $options, default: $default, hints: $hints, ctx: array_merge($default_ctx, $ctx_overrides));
     }, $keystrokes);
   }
 
@@ -166,6 +166,48 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
 
     $this->assertNull($r['result']);
     $this->assertStringContainsString('(cancelled)', (string) $r['output']);
+  }
+
+  public function testDefaultPreChecksOptions(): void {
+    $r = $this->runMultiselectWidget(self::KEY_ENTER, [], [], [], ['ts', 'prettier']);
+
+    $this->assertSame(['ts', 'prettier'], $r['result']);
+  }
+
+  public function testDefaultRendersPreCheckedSelection(): void {
+    $r = $this->runMultiselectWidget(self::KEY_ENTER, [], [], [], ['ts', 'eslint']);
+
+    $this->assertSame(['ts', 'eslint'], $r['result']);
+    $this->assertStringContainsString('TypeScript, ESLint', (string) $r['output']);
+  }
+
+  public function testDefaultThenToggleOffYieldsEmpty(): void {
+    $r = $this->runMultiselectWidget(self::KEY_SPACE . self::KEY_ENTER, [], [], [], ['ts']);
+
+    $this->assertSame([], $r['result']);
+  }
+
+  public function testDefaultThenCheckAnother(): void {
+    $r = $this->runMultiselectWidget(self::KEY_DOWN . self::KEY_SPACE . self::KEY_ENTER, [], [], [], ['ts']);
+
+    $this->assertSame(['ts', 'eslint'], $r['result']);
+  }
+
+  public function testDefaultUnknownKeysIgnored(): void {
+    $r = $this->runMultiselectWidget(self::KEY_ENTER, [], [], [], ['nonexistent']);
+
+    $this->assertSame([], $r['result']);
+  }
+
+  public function testDefaultThreadsThroughFlowClosure(): void {
+    $r = $this->promptyRun(function (): mixed {
+      $closure = Prompty::multiselect('Features', options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'], default: ['ts']);
+      $this->assertInstanceOf(\Closure::class, $closure);
+
+      return $closure($this->defaultCtx());
+    }, self::KEY_ENTER);
+
+    $this->assertSame(['ts'], $r['result']);
   }
 
 }

--- a/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
 
 use AlexSkrypnyk\Prompty\Prompty;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -182,10 +183,19 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
     $this->assertStringContainsString('(cancelled)', (string) $r['output']);
   }
 
-  public function testDefaultPreChecksOptions(): void {
-    $r = $this->runMultiselectWidget(self::KEY_ENTER, [], [], [], ['ts', 'prettier']);
+  #[DataProvider('dataProviderDefault')]
+  public function testDefault(string $keystrokes, array $default, array $expected): void {
+    $r = $this->runMultiselectWidget($keystrokes, [], [], [], $default);
 
-    $this->assertSame(['ts', 'prettier'], $r['result']);
+    $this->assertSame($expected, $r['result']);
+  }
+
+  public static function dataProviderDefault(): \Iterator {
+    yield 'pre-checks options' => [self::KEY_ENTER, ['ts', 'prettier'], ['ts', 'prettier']];
+    yield 'all pre-checked' => [self::KEY_ENTER, ['ts', 'eslint', 'prettier'], ['ts', 'eslint', 'prettier']];
+    yield 'toggle off yields empty' => [self::KEY_SPACE . self::KEY_ENTER, ['ts'], []];
+    yield 'check another after default' => [self::KEY_DOWN . self::KEY_SPACE . self::KEY_ENTER, ['ts'], ['ts', 'eslint']];
+    yield 'unknown keys ignored' => [self::KEY_ENTER, ['nonexistent'], []];
   }
 
   public function testDefaultRendersPreCheckedSelection(): void {
@@ -193,24 +203,6 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
 
     $this->assertSame(['ts', 'eslint'], $r['result']);
     $this->assertStringContainsString('TypeScript, ESLint', (string) $r['output']);
-  }
-
-  public function testDefaultThenToggleOffYieldsEmpty(): void {
-    $r = $this->runMultiselectWidget(self::KEY_SPACE . self::KEY_ENTER, [], [], [], ['ts']);
-
-    $this->assertSame([], $r['result']);
-  }
-
-  public function testDefaultThenCheckAnother(): void {
-    $r = $this->runMultiselectWidget(self::KEY_DOWN . self::KEY_SPACE . self::KEY_ENTER, [], [], [], ['ts']);
-
-    $this->assertSame(['ts', 'eslint'], $r['result']);
-  }
-
-  public function testDefaultUnknownKeysIgnored(): void {
-    $r = $this->runMultiselectWidget(self::KEY_ENTER, [], [], [], ['nonexistent']);
-
-    $this->assertSame([], $r['result']);
   }
 
   public function testDefaultThreadsThroughFlowClosure(): void {

--- a/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyMultiselectInteractiveTest.php
@@ -17,6 +17,20 @@ final class PromptyMultiselectInteractiveTest extends PromptyTestCase {
 
   /**
    * Run the multiselect widget with injected keystrokes.
+   *
+   * @param string $keystrokes
+   *   Raw keystroke bytes to feed.
+   * @param array<string, string> $options
+   *   Map of option key to display label.
+   * @param array<string, string> $hints
+   *   Map of option key to hint text.
+   * @param array<string, mixed> $ctx_overrides
+   *   Optional context overrides.
+   * @param list<string> $default
+   *   Option keys to pre-check.
+   *
+   * @return array{result: mixed, output: string}
+   *   The widget return value and captured output.
    */
   protected function runMultiselectWidget(string $keystrokes, array $options = [], array $hints = [], array $ctx_overrides = [], array $default = []): array {
     if ($options === []) {

--- a/tests/phpunit/Unit/Prompty/PromptySelectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptySelectInteractiveTest.php
@@ -18,12 +18,12 @@ final class PromptySelectInteractiveTest extends PromptyTestCase {
   /**
    * Run the select widget with injected keystrokes.
    */
-  protected function runSelectWidget(string $keystrokes, array $options = [], array $hints = [], array $ctx_overrides = []): array {
+  protected function runSelectWidget(string $keystrokes, array $options = [], array $hints = [], array $ctx_overrides = [], string $default = ''): array {
     if ($options === []) {
       $options = ['react' => 'React', 'vue' => 'Vue', 'svelte' => 'Svelte'];
     }
 
-    return $this->promptyRun(function () use ($options, $hints, $ctx_overrides): mixed {
+    return $this->promptyRun(function () use ($options, $hints, $ctx_overrides, $default): mixed {
       $p = $this->createInstance();
       $default_ctx = [
         'depth' => 0,
@@ -33,7 +33,7 @@ final class PromptySelectInteractiveTest extends PromptyTestCase {
         'env_value' => NULL,
       ];
 
-      return Prompty::select('Framework', options: $options, hints: $hints, ctx: array_merge($default_ctx, $ctx_overrides));
+      return Prompty::select('Framework', options: $options, default: $default, hints: $hints, ctx: array_merge($default_ctx, $ctx_overrides));
     }, $keystrokes);
   }
 
@@ -175,6 +175,41 @@ final class PromptySelectInteractiveTest extends PromptyTestCase {
 
     $this->assertNull($r['result']);
     $this->assertStringContainsString('(cancelled)', (string) $r['output']);
+  }
+
+  public function testDefaultFocusesOption(): void {
+    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'vue');
+
+    $this->assertSame('vue', $r['result']);
+  }
+
+  public function testDefaultLastOption(): void {
+    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'svelte');
+
+    $this->assertSame('svelte', $r['result']);
+  }
+
+  public function testDefaultThenNavigate(): void {
+    $r = $this->runSelectWidget(self::KEY_DOWN . self::KEY_ENTER, [], [], [], 'vue');
+
+    $this->assertSame('svelte', $r['result']);
+  }
+
+  public function testDefaultUnknownFallsBackToFirst(): void {
+    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'nonexistent');
+
+    $this->assertSame('react', $r['result']);
+  }
+
+  public function testDefaultThreadsThroughFlowClosure(): void {
+    $r = $this->promptyRun(function (): mixed {
+      $closure = Prompty::select('Framework', options: ['react' => 'React', 'vue' => 'Vue'], default: 'vue');
+      $this->assertInstanceOf(\Closure::class, $closure);
+
+      return $closure($this->defaultCtx());
+    }, self::KEY_ENTER);
+
+    $this->assertSame('vue', $r['result']);
   }
 
 }

--- a/tests/phpunit/Unit/Prompty/PromptySelectInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptySelectInteractiveTest.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
 
 use AlexSkrypnyk\Prompty\Prompty;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -177,28 +178,18 @@ final class PromptySelectInteractiveTest extends PromptyTestCase {
     $this->assertStringContainsString('(cancelled)', (string) $r['output']);
   }
 
-  public function testDefaultFocusesOption(): void {
-    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'vue');
+  #[DataProvider('dataProviderDefault')]
+  public function testDefault(string $keystrokes, string $default, string $expected): void {
+    $r = $this->runSelectWidget($keystrokes, [], [], [], $default);
 
-    $this->assertSame('vue', $r['result']);
+    $this->assertSame($expected, $r['result']);
   }
 
-  public function testDefaultLastOption(): void {
-    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'svelte');
-
-    $this->assertSame('svelte', $r['result']);
-  }
-
-  public function testDefaultThenNavigate(): void {
-    $r = $this->runSelectWidget(self::KEY_DOWN . self::KEY_ENTER, [], [], [], 'vue');
-
-    $this->assertSame('svelte', $r['result']);
-  }
-
-  public function testDefaultUnknownFallsBackToFirst(): void {
-    $r = $this->runSelectWidget(self::KEY_ENTER, [], [], [], 'nonexistent');
-
-    $this->assertSame('react', $r['result']);
+  public static function dataProviderDefault(): \Iterator {
+    yield 'focuses option' => [self::KEY_ENTER, 'vue', 'vue'];
+    yield 'focuses last option' => [self::KEY_ENTER, 'svelte', 'svelte'];
+    yield 'navigable after focus' => [self::KEY_DOWN . self::KEY_ENTER, 'vue', 'svelte'];
+    yield 'unknown falls back to first' => [self::KEY_ENTER, 'nonexistent', 'react'];
   }
 
   public function testDefaultThreadsThroughFlowClosure(): void {

--- a/tests/phpunit/Unit/Prompty/PromptyTextInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyTextInteractiveTest.php
@@ -25,12 +25,14 @@ final class PromptyTextInteractiveTest extends PromptyTestCase {
    *   Raw keystroke bytes to feed.
    * @param array<string, mixed> $ctx_overrides
    *   Optional context overrides.
+   * @param string $default
+   *   Pre-filled, editable initial value.
    *
    * @return array{result: mixed, output: string}
    *   The widget return value and captured output.
    */
-  protected function runTextWidget(string $keystrokes, array $ctx_overrides = []): array {
-    return $this->promptyRun(function () use ($ctx_overrides): mixed {
+  protected function runTextWidget(string $keystrokes, array $ctx_overrides = [], string $default = ''): array {
+    return $this->promptyRun(function () use ($ctx_overrides, $default): mixed {
       $p = $this->createInstance();
       $default_ctx = [
         'depth' => 0,
@@ -40,7 +42,7 @@ final class PromptyTextInteractiveTest extends PromptyTestCase {
         'env_value' => NULL,
       ];
 
-      return Prompty::text('Project name', placeholder: 'my-app', description: 'Enter a name.', ctx: array_merge($default_ctx, $ctx_overrides));
+      return Prompty::text('Project name', default: $default, placeholder: 'my-app', description: 'Enter a name.', ctx: array_merge($default_ctx, $ctx_overrides));
     }, $keystrokes);
   }
 
@@ -158,6 +160,41 @@ final class PromptyTextInteractiveTest extends PromptyTestCase {
     $r = $this->runTextWidget('a b' . self::KEY_ENTER);
 
     $this->assertSame('a b', $r['result']);
+  }
+
+  public function testDefaultPreFillsValue(): void {
+    $r = $this->runTextWidget(self::KEY_ENTER, [], 'seed-name');
+
+    $this->assertSame('seed-name', $r['result']);
+  }
+
+  public function testDefaultIsEditable(): void {
+    $r = $this->runTextWidget(self::KEY_BACKSPACE . 'x' . self::KEY_ENTER, [], 'abc');
+
+    $this->assertSame('abx', $r['result']);
+  }
+
+  public function testDefaultClearedFallsBackToPlaceholder(): void {
+    $r = $this->runTextWidget(self::KEY_BACKSPACE . self::KEY_BACKSPACE . self::KEY_ENTER, [], 'ab');
+
+    $this->assertSame('my-app', $r['result']);
+  }
+
+  public function testDefaultShownInActiveState(): void {
+    $r = $this->runTextWidget('x' . self::KEY_ENTER, [], 'preset');
+
+    $this->assertStringContainsString('preset', $r['output']);
+  }
+
+  public function testDefaultThreadsThroughFlowClosure(): void {
+    $r = $this->promptyRun(function (): mixed {
+      $closure = Prompty::text('Name', default: 'from-closure', placeholder: 'ph');
+      $this->assertInstanceOf(\Closure::class, $closure);
+
+      return $closure($this->defaultCtx());
+    }, self::KEY_ENTER);
+
+    $this->assertSame('from-closure', $r['result']);
   }
 
 }

--- a/tests/phpunit/Unit/Prompty/PromptyTextInteractiveTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyTextInteractiveTest.php
@@ -162,22 +162,17 @@ final class PromptyTextInteractiveTest extends PromptyTestCase {
     $this->assertSame('a b', $r['result']);
   }
 
-  public function testDefaultPreFillsValue(): void {
-    $r = $this->runTextWidget(self::KEY_ENTER, [], 'seed-name');
+  #[DataProvider('dataProviderDefault')]
+  public function testDefault(string $keystrokes, string $default, string $expected): void {
+    $r = $this->runTextWidget($keystrokes, [], $default);
 
-    $this->assertSame('seed-name', $r['result']);
+    $this->assertSame($expected, $r['result']);
   }
 
-  public function testDefaultIsEditable(): void {
-    $r = $this->runTextWidget(self::KEY_BACKSPACE . 'x' . self::KEY_ENTER, [], 'abc');
-
-    $this->assertSame('abx', $r['result']);
-  }
-
-  public function testDefaultClearedFallsBackToPlaceholder(): void {
-    $r = $this->runTextWidget(self::KEY_BACKSPACE . self::KEY_BACKSPACE . self::KEY_ENTER, [], 'ab');
-
-    $this->assertSame('my-app', $r['result']);
+  public static function dataProviderDefault(): \Iterator {
+    yield 'pre-fills value' => [self::KEY_ENTER, 'seed-name', 'seed-name'];
+    yield 'editable' => [self::KEY_BACKSPACE . 'x' . self::KEY_ENTER, 'abc', 'abx'];
+    yield 'cleared falls back to placeholder' => [self::KEY_BACKSPACE . self::KEY_BACKSPACE . self::KEY_ENTER, 'ab', 'my-app'];
   }
 
   public function testDefaultShownInActiveState(): void {

--- a/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
@@ -399,70 +399,56 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
     $this->assertStringContainsString('(2.1)', $output);
   }
 
-  public function testTextDefaultYieldsToDiscovered(): void {
-    $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::text('Name', default: 'seed', discovered: 'disc', ctx: $this->ctx());
+  #[DataProvider('dataProviderTextDefaultPrecedence')]
+  public function testTextDefaultPrecedence(?string $discovered, ?string $env_value, string $expected): void {
+    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
+      $result = Prompty::text('Name', default: 'seed', discovered: $discovered, ctx: $this->ctx(['env_value' => $env_value]));
     });
 
-    $this->assertSame('disc', $result);
+    $this->assertSame($expected, $result);
   }
 
-  public function testTextDefaultYieldsToEnv(): void {
-    $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::text('Name', default: 'seed', ctx: $this->ctx(['env_value' => 'env-val']));
-    });
-
-    $this->assertSame('env-val', $result);
+  public static function dataProviderTextDefaultPrecedence(): \Iterator {
+    yield 'discovered wins over default' => ['disc', NULL, 'disc'];
+    yield 'env wins over default' => [NULL, 'env-val', 'env-val'];
   }
 
-  public function testSelectDefaultYieldsToDiscovered(): void {
-    $this->captureOutput(function () use (&$result): void {
+  #[DataProvider('dataProviderSelectDefaultPrecedence')]
+  public function testSelectDefaultPrecedence(?string $discovered, ?string $env_value, string $expected): void {
+    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
       $result = Prompty::select('Framework',
         options: ['react' => 'React', 'vue' => 'Vue'],
         default: 'vue',
-        discovered: 'react',
-        ctx: $this->ctx(),
+        discovered: $discovered,
+        ctx: $this->ctx(['env_value' => $env_value]),
       );
     });
 
-    $this->assertSame('react', $result);
+    $this->assertSame($expected, $result);
   }
 
-  public function testSelectDefaultYieldsToEnv(): void {
-    $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::select('Framework',
-        options: ['react' => 'React', 'vue' => 'Vue'],
-        default: 'vue',
-        ctx: $this->ctx(['env_value' => 'react']),
-      );
-    });
-
-    $this->assertSame('react', $result);
+  public static function dataProviderSelectDefaultPrecedence(): \Iterator {
+    yield 'discovered wins over default' => ['react', NULL, 'react'];
+    yield 'env wins over default' => [NULL, 'react', 'react'];
   }
 
-  public function testMultiselectDefaultYieldsToDiscovered(): void {
-    $this->captureOutput(function () use (&$result): void {
+  #[DataProvider('dataProviderMultiselectDefaultPrecedence')]
+  public function testMultiselectDefaultPrecedence(?array $discovered, ?string $env_value, array $expected): void {
+    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
       $result = Prompty::multiselect('Features',
         options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
         default: ['ts'],
-        discovered: ['eslint'],
-        ctx: $this->ctx(),
+        discovered: $discovered,
+        ctx: $this->ctx(['env_value' => $env_value]),
       );
     });
 
-    $this->assertSame(['eslint'], $result);
+    $this->assertSame($expected, $result);
   }
 
-  public function testMultiselectDefaultYieldsToEnv(): void {
-    $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::multiselect('Features',
-        options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
-        default: ['ts'],
-        ctx: $this->ctx(['env_value' => 'eslint']),
-      );
-    });
-
-    $this->assertSame(['eslint'], $result);
+  public static function dataProviderMultiselectDefaultPrecedence(): \Iterator {
+    yield 'discovered wins over default' => [['eslint'], NULL, ['eslint']];
+    yield 'env wins over default' => [NULL, 'eslint', ['eslint']];
   }
 
 }

--- a/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
@@ -399,4 +399,70 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
     $this->assertStringContainsString('(2.1)', $output);
   }
 
+  public function testTextDefaultYieldsToDiscovered(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::text('Name', default: 'seed', discovered: 'disc', ctx: $this->ctx());
+    });
+
+    $this->assertSame('disc', $result);
+  }
+
+  public function testTextDefaultYieldsToEnv(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::text('Name', default: 'seed', ctx: $this->ctx(['env_value' => 'env-val']));
+    });
+
+    $this->assertSame('env-val', $result);
+  }
+
+  public function testSelectDefaultYieldsToDiscovered(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::select('Framework',
+        options: ['react' => 'React', 'vue' => 'Vue'],
+        default: 'vue',
+        discovered: 'react',
+        ctx: $this->ctx(),
+      );
+    });
+
+    $this->assertSame('react', $result);
+  }
+
+  public function testSelectDefaultYieldsToEnv(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::select('Framework',
+        options: ['react' => 'React', 'vue' => 'Vue'],
+        default: 'vue',
+        ctx: $this->ctx(['env_value' => 'react']),
+      );
+    });
+
+    $this->assertSame('react', $result);
+  }
+
+  public function testMultiselectDefaultYieldsToDiscovered(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::multiselect('Features',
+        options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
+        default: ['ts'],
+        discovered: ['eslint'],
+        ctx: $this->ctx(),
+      );
+    });
+
+    $this->assertSame(['eslint'], $result);
+  }
+
+  public function testMultiselectDefaultYieldsToEnv(): void {
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::multiselect('Features',
+        options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
+        default: ['ts'],
+        ctx: $this->ctx(['env_value' => 'eslint']),
+      );
+    });
+
+    $this->assertSame(['eslint'], $result);
+  }
+
 }


### PR DESCRIPTION
Closes #21

## Summary

Adds a `default` parameter to the `text`, `select`, and `multiselect` widgets so callers can seed the interactive starting state with a sensible answer that the user can accept or adjust. The `confirm` widget already had `default`; this change brings the remaining three widgets to the same standard. A value supplied via `discovered` or a `PROMPTY_*` environment variable still takes precedence and bypasses the prompt entirely, so explicit input always wins over the default.

## Changes

**`Prompty.php` - new `default` parameter on three widgets**
- `text(string $label, string $default = '', ...)` - `default` is placed after `label` (consistent with `confirm`) and pre-fills the editable input buffer; `placeholder` remains the gray hint shown only when the buffer is empty.
- `select(string $label, array $options = [], string $default = '', ...)` - `default` is placed after `options` (matching Laravel Prompts convention) and focuses the matching option key on first render; falls back to index 0 if the key is not found.
- `multiselect(string $label, array $options = [], array $default = [], ...)` - `default` is placed after `options` and pre-checks the listed keys on first render; unknown keys are silently ignored.
- All three widgets thread `default` through the flow-mode closure so the value is preserved when called deferred.

**Tests - 22 new unit tests across four test classes**
- `PromptyTextInteractiveTest` - default pre-fills, is editable, can be cleared, appears in active render, threads through flow closure.
- `PromptySelectInteractiveTest` - focuses option, focuses last option, navigable after focus, unknown key falls back to first, threads through flow closure.
- `PromptyMultiselectInteractiveTest` - pre-checks list, renders checked labels, toggle-off yields empty, toggling on additional key, unknown keys ignored, threads through flow closure.
- `PromptyWidgetResolvedTest` - `discovered` and env-var precedence over `default` for all three widgets (6 tests).

**README.md**
- Updated `text`, `select`, and `multiselect` widget sections with `default` in their code examples and a short prose note distinguishing it from `placeholder` / describing the focus/pre-check behavior.
- New "Default values" section with a summary table and an opt-out list example.

**Playground demos**
- `playground/widget-text.php` - added "with editable default" demo.
- `playground/widget-select.php` - added "with default (pre-focused)" demo.
- `playground/widget-multiselect.php` - added "opt-out (pre-checked default)" demo.

## Before / After

**`text` widget - input buffer state on first render**

```
Before                          After (default: 'my-app')
┌─────────────────────────┐     ┌─────────────────────────┐
│ Project name            │     │ Project name            │
│ ▏                       │     │ my-app▏                 │
│ my-app      (gray hint) │     │                         │
└─────────────────────────┘     └─────────────────────────┘
  placeholder shown              default pre-filled, editable
```

**`select` widget - focused row on first render**

```
Before                          After (default: 'vue')
┌─────────────────────────┐     ┌─────────────────────────┐
│ Framework               │     │ Framework               │
│ › React        ◀ focus  │     │   React                 │
│   Vue                   │     │ › Vue          ◀ focus  │
│   Svelte                │     │   Svelte                │
└─────────────────────────┘     └─────────────────────────┘
```

**`multiselect` widget - checked state on first render**

```
Before                                  After (default: ['ts','eslint','prettier'])
┌─────────────────────────────┐         ┌─────────────────────────────┐
│ Features                    │         │ Features                    │
│ › ◯ TypeScript              │         │ › ◉ TypeScript              │
│   ◯ ESLint                  │         │   ◉ ESLint                  │
│   ◯ Prettier                │         │   ◉ Prettier                │
└─────────────────────────────┘         └─────────────────────────────┘
  all unchecked (opt-in)                  all pre-checked (opt-out)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for `default` parameter to the `text`, `select`, and `multiselect` interactive widgets, allowing callers to seed the initial state of these inputs.

## Key Changes

**Prompty.php**
- `text()`: Added `$default` parameter (after `$label`) to pre-fill the editable input buffer; `placeholder` remains the hint shown only when buffer is empty
- `select()`: Added `$default` parameter (after `$options`) to focus the matching option key on first render; falls back to index 0 if key not found
- `multiselect()`: Added `$default` parameter (after `$options`) to pre-check listed keys on first render; unknown keys are ignored
- All three widgets thread `default` through the flow-mode closure for deferred execution

**Behavior and Precedence**
- Values supplied via `discovered` or environment variables (`PROMPTY_*`) still take precedence and bypass the prompt, overriding defaults
- Defaults only seed interactive state when no external value is provided

**Tests**
- Added 22 new unit tests across four test classes:
  - `PromptyTextInteractiveTest`: Tests for pre-fill behavior, editability, and flow-mode threading
  - `PromptySelectInteractiveTest`: Tests for pre-focus behavior, navigation, unknown-key fallback, and flow-mode threading  
  - `PromptyMultiselectInteractiveTest`: Tests for pre-check behavior, toggling, unknown-key handling, and flow-mode threading
  - `PromptyWidgetResolvedTest`: Tests for precedence of `discovered` and environment variables over defaults

**Documentation**
- `README.md`: Updated examples for all three widgets and added a new "Default values" section documenting the feature
- Playground demos: Added examples demonstrating editable default (text), pre-focused default (select), and pre-checked default (multiselect)

## Use Case

Enables "opt-out" UX patterns (e.g., all items pre-checked in multiselect) without awkward inverted wording, addressing the requirement from downstream tools like drupal_extension_scaffold.

Closes `#21`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->