### PR TITLE
[#40] Fixed the shipped test trait usage example.

### DIFF
--- a/PromptyTestTrait.php
+++ b/PromptyTestTrait.php
@@ -10,23 +10,37 @@ namespace AlexSkrypnyk\Prompty;
  * Ships alongside Prompty.php. Include in a PHPUnit test case to simulate
  * keystrokes, capture output, and assert on results without a real TTY.
  *
- * Usage:
+ * Use promptyRun() when the callback returns the value under test:
  * @code
+ *   use AlexSkrypnyk\Prompty\Prompty;
+ *   use AlexSkrypnyk\Prompty\PromptyTestTrait;
  *   use PHPUnit\Framework\TestCase;
- *   require_once __DIR__ . '/PromptyTestTrait.php';
  *
  *   class MyTest extends TestCase {
  *     use PromptyTestTrait;
  *
  *     public function testMyFlow(): void {
- *       $r = $this->promptyRun(function (): void {
- *         putenv('PROMPTY_STOP=1');
- *         require 'my-installer.php';
- *       }, self::KEY_DOWN . self::KEY_ENTER);
+ *       $r = $this->promptyRun(fn(): mixed => Prompty::flow(fn(): array => [
+ *         'framework' => Prompty::select('Framework', options: [
+ *           'react' => 'React',
+ *           'vue' => 'Vue',
+ *         ]),
+ *       ]), self::KEY_DOWN . self::KEY_ENTER);
  *
  *       $this->assertSame('vue', $r['result']['framework']);
  *     }
  *   }
+ * @endcode
+ *
+ * Use promptyRunScript() to drive a consumer script. Leave the script's kill
+ * switch variable unset so it stops before doing real work, then read the
+ * answers from Prompty::results():
+ * @code
+ *   $this->promptyRunScript(function (): void {
+ *     require 'my-installer.php';
+ *   }, self::KEY_DOWN . self::KEY_ENTER);
+ *
+ *   $this->assertSame('vue', Prompty::results()['framework']);
  * @endcode
  */
 trait PromptyTestTrait {
@@ -101,11 +115,10 @@ trait PromptyTestTrait {
   /**
    * Run a consumer script with simulated keystrokes.
    *
-   * Unlike promptyRun(), this does NOT pre-set the singleton or $inFlow.
-   * The script's own Prompty::flow() call handles all setup. This method
-   * only injects the keystroke stream and captures output.
-   *
-   * After calling this, use Prompty::results() to read collected answers.
+   * Installs a singleton carrying the keystroke stream, which the script's
+   * own Prompty::flow() call then reuses. Unlike promptyRun(), $inFlow is
+   * left FALSE and the singleton survives the call, so Prompty::results()
+   * still reads the collected answers afterwards.
    *
    * @param callable $callback
    *   Typically: function () { require 'my-script.php'; }.

--- a/tests/phpunit/Unit/Prompty/PromptyTraitExampleTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyTraitExampleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Guards the usage example in PromptyTestTrait's class docblock.
+ *
+ * The example ships to consumers as the first thing they copy, so it is
+ * mirrored here to keep it executable.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyTraitExampleTest extends PromptyTestCase {
+
+  public function testDocumentedExample(): void {
+    $r = $this->promptyRun(fn(): mixed => Prompty::flow(fn(): array => [
+      'framework' => Prompty::select('Framework', options: ['react' => 'React', 'vue' => 'Vue']),
+    ]), self::KEY_DOWN . self::KEY_ENTER);
+
+    $this->assertIsArray($r['result']);
+    $this->assertSame('vue', $r['result']['framework']);
+  }
+
+}


### PR DESCRIPTION
Closes #40

## Summary

The class docblock on `PromptyTestTrait.php` carried a usage example that could not actually run: it referenced an environment variable the library never implements, its callback returned no value for the example's own assertion to check, and it drove the example through the wrong test helper for that scenario. Since this trait ships as public API, that docblock is the first code a consumer copies, so the example is rewritten into two accurate, executable cases and backed by a test that runs the documented example directly so it cannot silently rot again.

## Changes

- Rewrote the class docblock in `PromptyTestTrait.php` into two worked examples: `promptyRun()` for a callback that returns the value under test, and `promptyRunScript()` for driving a consumer script and reading answers back afterwards from `Prompty::results()`.
- Replaced the nonexistent `putenv('PROMPTY_STOP=1')` line with the real convention used elsewhere in the library (`starter.php`, `embed.php`): a script stops when its `SHOULD_PROCEED`-style kill switch variable is *absent*, not when some other variable is set.
- Wrapped the `promptyRun()` example's widget call in `Prompty::flow()`, since `promptyRun()` sets `inFlow = TRUE` before invoking the callback, so a bare `Prompty::select()` call inside it would return a `Closure` rather than a value.
- Corrected `promptyRunScript()`'s own docblock, which claimed it does NOT pre-set the singleton while the method body sets it two lines below that comment.
- Added `tests/phpunit/Unit/Prompty/PromptyTraitExampleTest.php`, which executes the documented example so a future edit that breaks it fails CI instead of shipping silently.

## Screenshots

N/A

## Before / After

Before, the docblock's only example read:
```php
$r = $this->promptyRun(function (): void {
  putenv('PROMPTY_STOP=1');
  require 'my-installer.php';
}, self::KEY_DOWN . self::KEY_ENTER);

$this->assertSame('vue', $r['result']['framework']);
```
This is broken three ways: `PROMPTY_STOP` is implemented nowhere in the library, so setting it does nothing; the callback is typed `void`, so `promptyRun()` returns `result = NULL` and the assertion on `$r['result']['framework']` can never pass; and `promptyRun()` is the wrong helper for a `require`-driven consumer script, since `promptyRunScript()` is the one built to leave the singleton intact afterwards.

After, the example splits into the two real cases:
```php
$r = $this->promptyRun(fn(): mixed => Prompty::flow(fn(): array => [
  'framework' => Prompty::select('Framework', options: [
    'react' => 'React',
    'vue' => 'Vue',
  ]),
]), self::KEY_DOWN . self::KEY_ENTER);

$this->assertSame('vue', $r['result']['framework']);
```
```php
$this->promptyRunScript(function (): void {
  require 'my-installer.php';
}, self::KEY_DOWN . self::KEY_ENTER);

$this->assertSame('vue', Prompty::results()['framework']);
```
The env-var polarity is flipped: the real convention stops a script when its kill switch variable is *absent*, not when some `PROMPTY_STOP` variable is set to `1`. The callback now returns a value (`Prompty::flow()` yields the array under `mixed`), so `promptyRun()`'s `result` is populated and the assertion actually exercises something. And the script-driving case now calls `promptyRunScript()`, the helper built for this exact case, so `Prompty::results()` works after the call returns.
