### PR TITLE
[#41] Stripped private-mode escape sequences in the test trait.

### DIFF
--- a/PromptyTestTrait.php
+++ b/PromptyTestTrait.php
@@ -150,9 +150,12 @@ trait PromptyTestTrait {
 
   /**
    * Strip ANSI escape codes from a string.
+   *
+   * The optional '?' covers private-mode sequences such as the cursor
+   * show/hide pair, which Prompty emits around every interactive widget.
    */
   protected function promptyStripAnsi(string $text): string {
-    return preg_replace('/\033\[[0-9;]*[A-Za-z]/', '', $text) ?? $text;
+    return preg_replace('/\033\[\??[0-9;]*[A-Za-z]/', '', $text) ?? $text;
   }
 
   /**

--- a/tests/phpunit/Unit/Prompty/PromptyStripAnsiTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyStripAnsiTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for the ANSI stripper shipped in PromptyTestTrait.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyStripAnsiTest extends PromptyTestCase {
+
+  #[DataProvider('dataProviderStripAnsi')]
+  public function testStripAnsi(string $text, string $expected): void {
+    $this->assertSame($expected, $this->stripAnsi($text));
+  }
+
+  public static function dataProviderStripAnsi(): \Iterator {
+    yield 'plain text' => ['hello', 'hello'];
+    yield 'reset' => ["\033[0mhello", 'hello'];
+    yield 'colour' => ["\033[36mhello\033[0m", 'hello'];
+    yield 'multi parameter' => ["\033[2;3mhello\033[0m", 'hello'];
+    yield 'cursor up' => ["\033[2Ahello", 'hello'];
+    yield 'hide cursor' => ["\033[?25lhello", 'hello'];
+    yield 'show cursor' => ["\033[?25hhello", 'hello'];
+    yield 'cursor pair around text' => ["\033[?25lhello\033[?25h", 'hello'];
+    yield 'mixed private and standard' => ["\033[?25l\033[36mhello\033[0m\033[?25h", 'hello'];
+    yield 'no escapes to strip' => ['[?25l', '[?25l'];
+  }
+
+  public function testStripAnsiRemovesCursorSequencesPromptyEmits(): void {
+    $p = $this->createInstance();
+
+    ob_start();
+    $this->callProtected($p, 'hideCursor');
+    $this->callProtected($p, 'showCursor');
+    $raw = ob_get_clean();
+
+    $this->assertIsString($raw);
+    $this->assertNotSame('', $raw);
+    $this->assertSame('', $this->stripAnsi($raw));
+  }
+
+}


### PR DESCRIPTION
Closes #41

## Summary

`PromptyTestTrait` ships as public API, and its `promptyStripAnsi()` used the pattern `/\033\[[0-9;]*[A-Za-z]/`, which cannot match private-mode escape sequences because `?` is not in the `[0-9;]` character class. Prompty itself emits exactly those sequences: `hideCursor()` writes `\033[?25l` and `showCursor()` writes `\033[?25h`, around every interactive widget and flow, so output returned from the shipped `promptyRun()` and `promptyRunScript()` helpers retained stray cursor bytes. The project's own functional harness (`FunctionalTestCase::stripAnsi()`) already stripped these sequences, so the two disagreed. This PR makes the `?` optional in the trait's pattern so it matches both standard and private-mode sequences, equivalent to the alternation the functional harness uses but tighter.

**Behaviour change in shipped code**: output returned by `promptyRun()` and `promptyRunScript()` now loses bytes it previously kept, since private-mode cursor escapes are now stripped along with standard ANSI escapes. No existing test depended on the old behaviour, but this is a real change to public-API output and should be called out in the release notes.

## Changes

### `PromptyTestTrait.php`

- Changed the `promptyStripAnsi()` regex from `/\033\[[0-9;]*[A-Za-z]/` to `/\033\[\??[0-9;]*[A-Za-z]/`, making the `?` optional so private-mode escape sequences are stripped along with standard ones.
- Added a docblock note explaining why the `?` is optional, referencing the cursor show/hide pair that Prompty emits around every interactive widget.

### `tests/phpunit/Unit/Prompty/PromptyStripAnsiTest.php` (new)

- Added a ten-case data provider covering plain text, a reset code, colour, multi-parameter codes, cursor-up, both private-mode cursor sequences individually, both together around text, mixed private and standard sequences, and a negative case (`[?25l` without the escape byte) that must not be stripped.
- Added a test that captures real output from Prompty's own `hideCursor()` and `showCursor()` and asserts it strips to an empty string.

### Not changed

- `FunctionalTestCase::stripAnsi()` keeps its own separate stripper by design; its docblock states it does not depend on Prompty internals, so the two implementations were deliberately not deduplicated. The remaining duplication between the two strippers is intentional, not an oversight.

## Screenshots

N/A

## Before / After

Old pattern: `/\033\[[0-9;]*[A-Za-z]/`

New pattern: `/\033\[\??[0-9;]*[A-Za-z]/`

Demonstrated on the input `"\033[?25lhello\033[?25h"`:

| Pattern | Result |
|---|---|
| Old | `[?25lhello[?25h` (private-mode cursor escape bytes retained) |
| New | `hello` (fully stripped) |
