### PR TITLE
[#44] Corrected comments that misstated what the code does.

### DIFF
--- a/.util/svg-term-render.js
+++ b/.util/svg-term-render.js
@@ -11,7 +11,8 @@
  * Options:
  *   --at <ms>          Timestamp of frame to render
  *   --line-height <n>  Line height multiplier (default: 1.0)
- *   --font-family <s>  Font family (default: Consolas, monospace)
+ *   --font-family <s>  Font family (default: Consolas, "Courier New",
+ *                      Courier, "Liberation Mono", monospace)
  */
 
 const fs = require('fs');
@@ -25,7 +26,7 @@ if (args.length < 2 || args.includes('--help')) {
   console.log('Options:');
   console.log('  --at <ms>          Timestamp of frame to render');
   console.log('  --line-height <n>  Line height multiplier (default: 1.0)');
-  console.log('  --font-family <s>  Font family (default: Consolas, monospace)');
+  console.log('  --font-family <s>  Font family (default: Consolas, "Courier New", Courier, "Liberation Mono", monospace)');
   process.exit(args.includes('--help') ? 0 : 1);
 }
 
@@ -97,7 +98,7 @@ if (lines.length > 0) {
   }
 }
 
-// Define custom theme with lineHeight set to 1.0.
+// Define custom theme with lineHeight from the --line-height option.
 // Based on Atom One Dark theme colors.
 // Note: svg-term 1.3.1 expects RGB arrays, not hex strings.
 const theme = {

--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -3,10 +3,12 @@
 
 /**
  * @file
- * Generate animated SVG assets from asciinema recordings.
+ * Generate SVG assets from asciinema recordings.
  *
- * Records terminal sessions for playground scripts (widgets, flow, flow-nested),
- * then converts the recordings to animated SVGs for use in README.md.
+ * Records terminal sessions for seven playground scripts in four flag
+ * variants each. The widgets, flow and flow-nested recordings render as
+ * animated SVGs; the widget-* recordings render as static single-frame
+ * SVGs. README.md references all of them except the widgets*.svg files.
  *
  * Supports parallel execution: when run without arguments, launches all
  * recordings as parallel worker processes for faster generation.
@@ -45,10 +47,10 @@ define('END_PAUSE', 10);
  *
  * @return array<string, array<string, mixed>>
  *   Keyed by job name, each containing script, expect_fn, rows, and
- *   optionally at (for static screenshots).
+ *   optionally at and cols (for static screenshots).
  */
 function getJobs(string $project_dir): array {
-  // Flag variants for animated recordings.
+  // Flag variants applied to both the animated and static bases.
   $variants = ['' => '', '-ascii' => ' --no-unicode', '-no-ansi' => ' --no-ansi', '-ascii-no-ansi' => ' --no-unicode --no-ansi'];
 
   $animated_bases = [
@@ -312,7 +314,8 @@ function recordSession(string $cast_file, string $expect_script, int $rows = TER
 /**
  * Post-process a cast file.
  *
- * Removes the spawn command line and sanitizes paths.
+ * Removes the spawn command line, appends an END_PAUSE event so the
+ * animation pauses before looping, and sanitizes paths.
  *
  * @param string $cast_file
  *   Path to the cast file.

--- a/Prompty.php
+++ b/Prompty.php
@@ -619,7 +619,9 @@ class Prompty {
       elseif ($key === 'space') {
         $value .= ' ';
       }
-      // Only accept printable ASCII characters (ord >= 32).
+      // Reject control bytes (ord < 32); accept printable ASCII and bytes
+      // 0x80-0xFF, so UTF-8 characters delivered one byte per readKey()
+      // call accumulate in the buffer.
       elseif (mb_strlen($key) === 1 && ord($key) >= 32) {
         $value .= $key;
       }
@@ -1541,7 +1543,8 @@ class Prompty {
    * @param int $depth
    *   The current nesting depth.
    * @param array<string, mixed> $options
-   *   Flow options (numbering, env_prefix, truthy, falsy).
+   *   Flow options; only the 'numbering' key is read. Env prefix, truthy
+   *   and falsy values come from the cfg* properties.
    * @param string $number_prefix
    *   Dot-separated prefix for hierarchical step numbering.
    *

--- a/embed.php
+++ b/embed.php
@@ -21,8 +21,8 @@
  * embedding is performed on the copy. Otherwise the source is modified
  * in place.
  *
- * After embedding, if Rector is available (vendor/bin/rector), it will be
- * run on the processed class content. A kill-switch block is injected after
+ * Before embedding, if Rector is available (vendor/bin/rector), it is run
+ * on the processed class content. A kill-switch block is injected after
  * the embed region if one is not already present. The embedded script is
  * then run to verify it works.
  *
@@ -205,7 +205,8 @@ for ($i = 0; $i < $token_count; $i++) {
     continue;
   }
 
-  // Skip the namespace declaration (re-added in the embedded output).
+  // Skip the namespace declaration; --stdout mode re-adds it, embedding
+  // inserts the class without one.
   if ($token_type === T_NAMESPACE) {
     while ($i < $token_count) {
       $i++;
@@ -332,8 +333,8 @@ if ($compact && $class_start !== NULL) {
     if ($token_type === T_VARIABLE && $visibility !== NULL) {
       $prop_name = substr($ctokens[$i][1], 1);
 
-      // Check if next non-whitespace is '(' - that would make it a
-      // method parameter, not a property.
+      // Treat as a property unless the preceding non-whitespace token is
+      // T_FUNCTION.
       $is_property = TRUE;
       for ($k = $i - 1; $k >= 0; $k--) {
         if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
@@ -432,7 +433,8 @@ if ($compact && $class_start !== NULL) {
       continue;
     }
 
-    // Skip property declarations and references (after -> or ::$).
+    // Skip names in the property map: declarations, static::$name
+    // references and same-named locals are renamed via $prop_map instead.
     if (isset($prop_map[$var_name])) {
       continue;
     }
@@ -479,7 +481,7 @@ if ($compact && $class_start !== NULL) {
         continue;
       }
 
-      // Static property reference: static::$propName.
+      // Property declaration or static::$propName reference.
       if (isset($prop_map[$var_name])) {
         $compact_output .= '$' . $prop_map[$var_name];
         continue;
@@ -570,7 +572,7 @@ if ($compact && $class_start !== NULL) {
         $after = is_array($ws_tokens[$i + 1]) ? $ws_tokens[$i + 1][1] : $ws_tokens[$i + 1];
       }
 
-      // Remove space if surrounded by non-alphanumeric/non-$ on both sides.
+      // Remove the space when either neighbour is a non-word character.
       $before_last = $before !== '' ? $before[strlen($before) - 1] : '';
       $after_first = $after !== '' ? $after[0] : '';
 


### PR DESCRIPTION
Closes #44

## Summary

A prior codebase-wide comment-register pass found comments whose claims did not match the surrounding code, and deliberately reported them without fixing them, since correcting a claim is a substantive change that deserves its own reviewed diff. This is that diff: fourteen comment corrections across four files, each verified against the current code before editing. No code defects were found - every mismatch was the comment describing the code incorrectly, not the reverse. The diff is comment-only except for exactly one line: `.util/svg-term-render.js`'s `--help` output printed the same abbreviated `--font-family` default as its docblock, so both were corrected together to keep the program's own usage text consistent with the documentation.

## Changes

### `Prompty.php`

- Corrected the text-buffer guard comment: it claimed only printable ASCII is accepted, but the guard also admits bytes `0x80`-`0xFF`, which `readKey()` requires because it reads one raw byte at a time and UTF-8 characters accumulate in the buffer byte by byte. The code was right; the comment was wrong.
- Corrected the `walkFlow()` docblock: it claimed `$options` carries `numbering`, `env_prefix`, `truthy`, and `falsy`, but `flow()` only ever sets `numbering` there, with the rest read from the `cfg*` properties instead.

### `embed.php`

- Corrected the pipeline comment: Rector runs *before* embedding, not after.
- Corrected the namespace comment: the namespace is re-added only in `--stdout` mode, not whenever embedding into a target.
- Corrected the property-vs-parameter comment: the check walks *backwards* looking for a preceding `T_FUNCTION`, not forwards for a `(`.
- Corrected the `->`/`::$` skip comment: it described a case that never reaches that `T_VARIABLE` check at all.
- Corrected the static-reference branch comment: it also catches property declarations, not only `static::$propName` references.
- Corrected the whitespace-collapse comment: the condition removes a space when *either* neighbour is a non-word character, not when *both* are.

### `.util/update-assets.php`

- Corrected the `@file` docblock: it claimed three recorded scripts, all animated, all feeding `README.md`; there are actually seven scripts across four flag variants, the `widget-*` families render static single-frame SVGs, and the four `widgets*.svg` outputs are referenced nowhere in `README.md`.
- Corrected the `$variants` comment: the flag variants are applied to the static bases too, not only the animated ones.
- Corrected `getJobs()`'s `@return` docblock: it omitted the optional `cols` key that `processOne()` reads.
- Corrected the `postProcessCast()` comment: it omitted that the function appends an `END_PAUSE` event.

### `.util/svg-term-render.js`

- Corrected the docblock and the `--help` output for `--font-family`: both stated an abbreviated default that did not match the actual default font stack. This is the one non-comment change in the PR - user-facing usage text, no behaviour change, now matching the real default exactly.
- Corrected the `lineHeight` comment: it stated a hardcoded `1.0`, but the value comes from the `--line-height` option.

## Screenshots

N/A

## Before / After

- **Text-buffer guard (`Prompty.php`)**: comment claimed "Only accept printable ASCII characters (ord >= 32)"; the guard actually accepts `ord >= 32` through `0xFF`, which is required for byte-wise UTF-8 accumulation in `readKey()` - the code was correct all along, the comment undersold it.
- **Embedding pipeline order (`embed.php`)**: comment claimed Rector runs "After embedding... on the processed class content"; Rector actually runs *before* embedding, so the comment had the pipeline order backwards.
- **Asset generator scope (`.util/update-assets.php`)**: `@file` docblock claimed "three recorded scripts, all animated, all feeding README.md"; the generator actually produces seven scripts across four flag variants, with the `widget-*` families rendering static single-frame SVGs and four `widgets*.svg` outputs that `README.md` never references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Correct documentation and docblocks across four files to match current code behavior.
- Update documentation for buffer handling, options, embedding order, namespaces, token checks, whitespace processing, asset generation, return values, and event processing.
- Align `.util/svg-term-render.js` font-family help text with its documented default font stack.
- Document `END_PAUSE` processing in `.util/update-assets.php`.
- No runtime behavior or public declarations change.

## Possibly related

- Possibly related to [PR `#44`](https://github.com/AlexSkrypnyk/prompty/pull/44), which also corrected comments that misstated code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->