### PR TITLE
[#49] Corrected test locations and recorded the widget parameter order.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,34 @@ Namespace: `AlexSkrypnyk\Prompty`. Key files: `Prompty.php` (library),
 
 ## Architecture
 
-- **Singleton** — `static::$instance`, never `new Prompty()`.
-- **Dual-mode widgets** — `text`, `select`, `multiselect`, `confirm` return
+- **Singleton** - `static::$instance`, never `new Prompty()`.
+- **Dual-mode widgets** - `text`, `select`, `multiselect`, `confirm` return
   closures in flow mode, values in standalone mode.
-- **Typed config properties** — `cfgUnicode`, `cfgSymbols`, `cfgColors`,
+- **Typed config properties** - `cfgUnicode`, `cfgSymbols`, `cfgColors`,
   `cfgSpacing`, `cfgLabels`, `cfgEnvPrefix`, `cfgTruthy`, `cfgFalsy`, etc.
   Configured via `Prompty::configure(...)` named arguments.
-- **Flow definition** — `flow()` takes a callable (not array) so `$inFlow`
+- **Flow definition** - `flow()` takes a callable (not array) so `$inFlow`
   is set before widget evaluation.
-- **Tree rendering** — nested children use bar connectors; `open` array
+- **Tree rendering** - nested children use bar connectors; `open` array
   tracks continuing siblings.
+- **Widget signatures** - all four widgets share one parameter order, and any
+  new widget follows it:
+
+  ```
+  label, [options], default, [placeholder], [description], [hints],
+  discovered, condition, children, ctx
+  ```
+
+  Bracketed parameters appear only where they apply: `options` and `hints` on
+  `select`/`multiselect`, `placeholder` on `text`. The trailing four are
+  common to every widget. Callers pass `label` positionally and everything
+  else by name, so the order matters to the signature, not to call sites.
 
 ### Playground
 
-- `playground/widgets.php` — standalone widget demos.
-- `playground/flow.php` — linear flow.
-- `playground/flow-nested.php` — nested flow with conditionals.
+- `playground/widgets.php` - standalone widget demos.
+- `playground/flow.php` - linear flow.
+- `playground/flow-nested.php` - nested flow with conditionals.
 
 ## Commands
 
@@ -37,9 +49,9 @@ composer reset         # rm vendor/, reinstall
 
 ## Code Quality
 
-1. **PHPCS** — Drupal standard + strict types (`phpcs.xml`)
-2. **PHPStan** — Level 9 (`phpstan.neon`)
-3. **Rector** — PHP 8.2/8.3 modernization (`rector.php`)
+1. **PHPCS** - Drupal standard + strict types (`phpcs.xml`)
+2. **PHPStan** - Level 9 (`phpstan.neon`)
+3. **Rector** - PHP 8.2/8.3 modernization (`rector.php`)
 
 ## Conventions
 
@@ -52,6 +64,7 @@ composer reset         # rm vendor/, reinstall
 - Namespace: `AlexSkrypnyk\Prompty\Tests\Unit\Prompty`
 - Base class: `PromptyTestCase` (uses `PromptyTestTrait`)
 - PHPUnit 11: `#[CoversClass()]`, `#[DataProvider()]`
-- Tests in `tests/phpunit/Unit/Prompty/`
-- `StarterScriptTest` in `tests/phpunit/Unit/`
+- Unit tests in `tests/phpunit/Unit/Prompty/`
+- Functional tests in `tests/phpunit/Functional/` - these run `embed.php` and
+  `starter.php` in real subprocesses
 - Autoload: classmap (no PSR-4)


### PR DESCRIPTION
Closes #49

## Summary

`CLAUDE.md` had drifted from the code it describes: it pointed to the wrong location for `StarterScriptTest`, and it never wrote down the parameter order that all 4 widgets already share. It also used em dashes throughout, in violation of the project's own hyphen-only rule. This PR fixes all 3, touching only `CLAUDE.md` - no code changes.

## Changes

- Corrected the test-location entry - `tests/phpunit/Unit/` contains only the `Prompty/` subdirectory, and `StarterScriptTest` actually lives in `tests/phpunit/Functional/` alongside `EmbedScriptTest` and `FunctionalTestCase`. The entry now describes both trees and notes that the functional tests run `embed.php` and `starter.php` in real subprocesses.
- Recorded the widget parameter order - verified against all 4 signatures in `Prompty.php` before documenting: `label, [options], default, [placeholder], [description], [hints], discovered, condition, children, ctx`, where bracketed parameters appear only where they apply (`options`/`hints` on `select` and `multiselect`, `placeholder` on `text`) and the trailing 4 are common to every widget. The note also records that callers pass `label` positionally and everything else by name, so the order binds the signature rather than call sites.
- Removed 11 em dashes from the Architecture, Playground, and Code Quality sections and replaced them with regular hyphens, matching the hyphen-only rule the document itself declares.

Existing line wrapping in `CLAUDE.md` was left as-is - rewrapping the file would produce a large diff nobody asked for, so the new content matches the surrounding wrapped style.

**Scope note**: issue #49 originally also covered the kill-switch prose spelling and the duplicated usage text in `embed.php`. Both moved to #46, which already rewrites that usage text for the positional-argument rename, because they edit the same `@file` docblock region that #44 touches and would have conflicted with this change. This PR is documentation-only and independent of every other open PR.

## Screenshots

N/A

## Before / After

**Test locations**

Before: `CLAUDE.md` claimed `StarterScriptTest` lives in `tests/phpunit/Unit/` - but that directory holds only the `Prompty/` subdirectory, so the claim didn't match the tree.

After: `CLAUDE.md` describes both trees - unit tests in `tests/phpunit/Unit/Prompty/`, and functional tests (`StarterScriptTest`, `EmbedScriptTest`, `FunctionalTestCase`) in `tests/phpunit/Functional/`, which run `embed.php` and `starter.php` in real subprocesses.

**Widget parameter order**

Before: nothing in `CLAUDE.md` recorded the parameter order the 4 widgets already followed, so the next widget added was as likely to break it as to follow it.

After: `CLAUDE.md` documents the order explicitly:

```
label, [options], default, [placeholder], [description], [hints], discovered, condition, children, ctx
```
