### PR TITLE
[#43] Renamed the env_value context key to discovered.

### DIFF
--- a/Prompty.php
+++ b/Prompty.php
@@ -547,7 +547,7 @@ class Prompty {
     $open = $ctx['open'] ?? [];
     $label = $p->numberLabel($label, $ctx);
 
-    $resolved = $discovered ?? $ctx['env_value'] ?? NULL;
+    $resolved = $discovered ?? $ctx['discovered'] ?? NULL;
 
     if ($resolved !== NULL) {
       /** @var int|float|string|bool $resolved */
@@ -704,7 +704,7 @@ class Prompty {
     $option_labels = array_values($options);
     $ordered_hints = array_map(fn(int|string $key) => $hints[$key] ?? '', $option_keys);
 
-    $resolved = $discovered ?? $ctx['env_value'] ?? NULL;
+    $resolved = $discovered ?? $ctx['discovered'] ?? NULL;
 
     if ($resolved !== NULL) {
       /** @var int|float|string|bool $resolved */
@@ -881,9 +881,9 @@ class Prompty {
     $ordered_hints = array_map(fn(int|string $key) => $hints[$key] ?? '', $option_keys);
 
     // Env values for multiselect arrive comma-separated (e.g., "a,b,c").
-    $env_value = $ctx['env_value'] ?? NULL;
-    /** @var int|float|string|bool|null $env_value */
-    $resolved = $discovered ?? ($env_value !== NULL ? array_map(trim(...), explode(',', (string) $env_value)) : NULL);
+    $ctx_discovered = $ctx['discovered'] ?? NULL;
+    /** @var int|float|string|bool|null $ctx_discovered */
+    $resolved = $discovered ?? ($ctx_discovered !== NULL ? array_map(trim(...), explode(',', (string) $ctx_discovered)) : NULL);
 
     if ($resolved !== NULL) {
       $resolved_array = is_array($resolved) ? $resolved : [$resolved];
@@ -1063,10 +1063,10 @@ class Prompty {
     $falsy = $ctx['falsy'] ?? ['0', 'false', 'no'];
 
     // Env values for confirm need truthy/falsy coercion (e.g., "yes" → TRUE).
-    $env_value = $ctx['env_value'] ?? NULL;
-    /** @var int|float|string|bool|null $env_value */
-    if ($discovered === NULL && $env_value !== NULL) {
-      $env_lower = strtolower((string) $env_value);
+    $ctx_discovered = $ctx['discovered'] ?? NULL;
+    /** @var int|float|string|bool|null $ctx_discovered */
+    if ($discovered === NULL && $ctx_discovered !== NULL) {
+      $env_lower = strtolower((string) $ctx_discovered);
       if (in_array($env_lower, $truthy, TRUE)) {
         $discovered = TRUE;
       }
@@ -1621,7 +1621,7 @@ class Prompty {
         'open' => $this->open,
         'results' => $this->results,
         'number' => ($options['numbering'] ?? FALSE) ? $number : NULL,
-        'env_value' => $env_value !== FALSE ? $env_value : NULL,
+        'discovered' => $env_value !== FALSE ? $env_value : NULL,
         'truthy' => $this->cfgTruthy,
         'falsy' => $this->cfgFalsy,
       ];

--- a/tests/phpunit/Unit/Prompty/PromptyTestCase.php
+++ b/tests/phpunit/Unit/Prompty/PromptyTestCase.php
@@ -34,7 +34,7 @@ abstract class PromptyTestCase extends TestCase {
    *   Context array.
    */
   protected function defaultCtx(array $overrides = []): array {
-    return array_merge(['depth' => 0, 'is_last' => FALSE, 'open' => [], 'number' => NULL, 'env_value' => NULL], $overrides);
+    return array_merge(['depth' => 0, 'is_last' => FALSE, 'open' => [], 'number' => NULL, 'discovered' => NULL], $overrides);
   }
 
   /**

--- a/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyWidgetResolvedTest.php
@@ -12,8 +12,8 @@ use PHPUnit\Framework\Attributes\Group;
 /**
  * Tests widget execution with pre-resolved values (no TTY interaction).
  *
- * Widgets are called with `discovered` or `env_value` in ctx so they skip
- * the interactive loop and return immediately.
+ * Widgets are called with the `discovered` argument or the `discovered` ctx
+ * key so they skip the interactive loop and return immediately.
  */
 #[CoversClass(Prompty::class)]
 #[Group('unit')]
@@ -55,7 +55,7 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
 
   public function testTextEnvResolved(): void {
     $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::text('Project name', ctx: $this->ctx(['env_value' => 'env-app']));
+      $result = Prompty::text('Project name', ctx: $this->ctx(['discovered' => 'env-app']));
     });
 
     $this->assertSame('env-app', $result);
@@ -63,7 +63,7 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
 
   public function testTextDiscoveredTakesPrecedenceOverEnv(): void {
     $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::text('Project name', discovered: 'direct', ctx: $this->ctx(['env_value' => 'from-env']));
+      $result = Prompty::text('Project name', discovered: 'direct', ctx: $this->ctx(['discovered' => 'from-env']));
     });
 
     $this->assertSame('direct', $result);
@@ -88,7 +88,7 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
 
   public function testSelectEnvResolved(): void {
     $this->captureOutput(function () use (&$result): void {
-      $result = Prompty::select('Framework', options: ['react' => 'React', 'vue' => 'Vue'], ctx: $this->ctx(['env_value' => 'vue']));
+      $result = Prompty::select('Framework', options: ['react' => 'React', 'vue' => 'Vue'], ctx: $this->ctx(['discovered' => 'vue']));
     });
 
     $this->assertSame('vue', $result);
@@ -104,11 +104,11 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
   }
 
   #[DataProvider('dataProviderMultiselectResolved')]
-  public function testMultiselectResolved(string $env_value, array $expected): void {
-    $this->captureOutput(function () use ($env_value, &$result): void {
+  public function testMultiselectResolved(string $ctx_discovered, array $expected): void {
+    $this->captureOutput(function () use ($ctx_discovered, &$result): void {
       $result = Prompty::multiselect('Features',
         options: ['ts' => 'TypeScript', 'eslint' => 'ESLint', 'prettier' => 'Prettier'],
-        ctx: $this->ctx(['env_value' => $env_value]),
+        ctx: $this->ctx(['discovered' => $ctx_discovered]),
       );
     });
 
@@ -139,9 +139,9 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
   }
 
   #[DataProvider('dataProviderConfirmResolved')]
-  public function testConfirmResolved(string $env_value, bool $expected): void {
-    $this->captureOutput(function () use ($env_value, &$result): void {
-      $result = Prompty::confirm('Install?', ctx: $this->ctx(['env_value' => $env_value]));
+  public function testConfirmResolved(string $ctx_discovered, bool $expected): void {
+    $this->captureOutput(function () use ($ctx_discovered, &$result): void {
+      $result = Prompty::confirm('Install?', ctx: $this->ctx(['discovered' => $ctx_discovered]));
     });
 
     $this->assertSame($expected, $result);
@@ -206,7 +206,7 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
     $output = $this->captureOutput(function () use (&$result): void {
       $result = Prompty::multiselect('Features',
         options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
-        ctx: $this->ctx(['depth' => 2, 'is_last' => FALSE, 'open' => [1 => TRUE, 2 => TRUE], 'env_value' => 'ts,eslint']),
+        ctx: $this->ctx(['depth' => 2, 'is_last' => FALSE, 'open' => [1 => TRUE, 2 => TRUE], 'discovered' => 'ts,eslint']),
       );
     });
 
@@ -332,9 +332,9 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
   }
 
   #[DataProvider('dataProviderTextDefaultPrecedence')]
-  public function testTextDefaultPrecedence(?string $discovered, ?string $env_value, string $expected): void {
-    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
-      $result = Prompty::text('Name', default: 'seed', discovered: $discovered, ctx: $this->ctx(['env_value' => $env_value]));
+  public function testTextDefaultPrecedence(?string $discovered, ?string $ctx_discovered, string $expected): void {
+    $this->captureOutput(function () use ($discovered, $ctx_discovered, &$result): void {
+      $result = Prompty::text('Name', default: 'seed', discovered: $discovered, ctx: $this->ctx(['discovered' => $ctx_discovered]));
     });
 
     $this->assertSame($expected, $result);
@@ -346,13 +346,13 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
   }
 
   #[DataProvider('dataProviderSelectDefaultPrecedence')]
-  public function testSelectDefaultPrecedence(?string $discovered, ?string $env_value, string $expected): void {
-    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
+  public function testSelectDefaultPrecedence(?string $discovered, ?string $ctx_discovered, string $expected): void {
+    $this->captureOutput(function () use ($discovered, $ctx_discovered, &$result): void {
       $result = Prompty::select('Framework',
         options: ['react' => 'React', 'vue' => 'Vue'],
         default: 'vue',
         discovered: $discovered,
-        ctx: $this->ctx(['env_value' => $env_value]),
+        ctx: $this->ctx(['discovered' => $ctx_discovered]),
       );
     });
 
@@ -365,13 +365,13 @@ final class PromptyWidgetResolvedTest extends PromptyTestCase {
   }
 
   #[DataProvider('dataProviderMultiselectDefaultPrecedence')]
-  public function testMultiselectDefaultPrecedence(?array $discovered, ?string $env_value, array $expected): void {
-    $this->captureOutput(function () use ($discovered, $env_value, &$result): void {
+  public function testMultiselectDefaultPrecedence(?array $discovered, ?string $ctx_discovered, array $expected): void {
+    $this->captureOutput(function () use ($discovered, $ctx_discovered, &$result): void {
       $result = Prompty::multiselect('Features',
         options: ['ts' => 'TypeScript', 'eslint' => 'ESLint'],
         default: ['ts'],
         discovered: $discovered,
-        ctx: $this->ctx(['env_value' => $env_value]),
+        ctx: $this->ctx(['discovered' => $ctx_discovered]),
       );
     });
 


### PR DESCRIPTION
Closes #43

## Summary

**Breaking change:** this is the one PR in this batch that breaks existing callers. The `env_value` context key is renamed to `discovered`, with no alias and no deprecation warning - a step closure that reads `$ctx['env_value']` will now silently get `NULL` instead of erroring. This needs to be called out prominently in the 0.7.0 release notes.

One value carried three names through the widget pipeline: the public `discovered:` argument (a caller's explicit override), the `env_value` context key (the same concept resolved from the environment by the flow walker), and internal `resolved`/`env_value` locals (the outcome of combining the two). This PR standardizes all of it on a single name, `discovered`.

The public `discovered:` named argument is unchanged, so no caller breaks on it. The `env_value` context key becomes `discovered`. Internal locals now read in the same vocabulary.

The project is pre-1.0 (0.6.0 released, 0.7.0 in draft), so a minor version bump can carry this cutover.

## Changes

- `text()` and `select()`: `$resolved = $discovered ?? $ctx['env_value'] ?? NULL;` becomes `$resolved = $discovered ?? $ctx['discovered'] ?? NULL;` - reads cleanly inline since neither widget post-processes the value.
- `multiselect()` and `confirm()`: these two post-process the context value (comma-splitting for `multiselect()`, truthy/falsy coercion for `confirm()`), so they need it in a local first. That local is named `$ctx_discovered` rather than `$discovered`, because `$discovered` already names the parameter in scope - `$ctx_discovered` is the same concept as the parameter, just sourced from `$ctx`. The parameter itself is never mutated.
- Flow walker: the context array now sets `'discovered' => $env_value !== FALSE ? $env_value : NULL` instead of `'env_value' => ...`. The walker's own `$env_value = getenv(...)` local is untouched - it genuinely is the environment value at that point, and only the context key it populates changed. The key names the role; the local names the source.
- `PromptyTestCase::defaultCtx()` and `PromptyWidgetResolvedTest` updated to match: ctx array entries and data-provider parameter names now say `discovered`/`ctx_discovered` instead of `env_value`, and the class docblock reflects the new vocabulary.
- `PromptyConfigTest::testUnicodeDetection()` and `testAnsiDetection()` keep their own `$env_value` locals as-is - those hold `LANG`/`NO_COLOR`/`TERM` values for unrelated environment-detection tests, not this pipeline.
- Behavior is byte-identical: `multiselect()`'s `array_map(trim(...), explode(',', ...))` comma-splitting and `confirm()`'s `strtolower` plus truthy/falsy `in_array` coercion are unchanged, just reading from the renamed local.
- Verified with `composer lint` (clean) and `composer test` (342 tests / 826 assertions - the same count as before, confirming nothing was added or dropped, just renamed), including all 46 cases in `PromptyWidgetResolvedTest`: every multiselect comma-split dataset and every confirm truthy/falsy variant.

## Screenshots

N/A

## Before / After

Before this PR, the same discovered value went by three different names depending on where you looked in the pipeline:

| Layer | Old name |
|---|---|
| Caller override | `discovered:` argument |
| Context key (env-resolved) | `ctx['env_value']` |
| Internal combined value | `$resolved` / `$env_value` locals |

After this PR, all three speak the same vocabulary:

| Layer | New name |
|---|---|
| Caller override | `discovered:` argument (unchanged) |
| Context key (env-resolved) | `ctx['discovered']` |
| Internal combined value | `$resolved` / `$ctx_discovered` locals |

For a consumer, the only required change is in step closures that read the context array directly:

```php
// Before
function (array $ctx) {
  $existing = $ctx['env_value'] ?? NULL;
  // ...
}

// After
function (array $ctx) {
  $existing = $ctx['discovered'] ?? NULL;
  // ...
}
```

There's no alias for the old key, so a closure still reading `$ctx['env_value']` won't error - it will just silently receive `NULL` and fall through to whatever the closure does for "nothing discovered". Any consumer step closure that touches the context array needs this one-line update.
