### PR TITLE
[#46] Disambiguated the two meanings of source in embed.php.

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -8,35 +8,15 @@
  *
  * @see https://github.com/AlexSkrypnyk/prompty
  *
- * Usage:
- *   php embed.php [options] <source-script> [<output-script>]
- *   php embed.php [options] --stdout <output-file>
+ * Run the script without arguments to see the usage, arguments and options.
  *
- * The source script must contain // @embed-start and // @embed-end markers.
- * The minified class will be inserted between these markers. Re-running on
- * a previously embedded script replaces the embedded region with the latest
- * class content while preserving all other code.
- *
- * If <output-script> is provided, the source is copied there first and the
- * embedding is performed on the copy. Otherwise the source is modified
- * in place.
+ * The target script must contain // @embed-start and // @embed-end markers.
+ * The minified class will be inserted between these markers.
  *
  * Before embedding, if Rector is available (vendor/bin/rector), it is run
- * on the processed class content. A kill-switch block is injected after
+ * on the processed class content. A kill switch block is injected after
  * the embed region if one is not already present. The embedded script is
  * then run to verify it works.
- *
- * Options:
- *   --source <path>  Path to the PHP class file to embed. Defaults to
- *                    Prompty.php in the same directory as this script.
- *   --compact        Apply additional size optimizations: shorten internal
- *                    property and method names, rename local variables,
- *                    reduce whitespace.
- *   --stdout         Output the processed class as a standalone PHP file
- *                    instead of embedding into a target script. Requires an
- *                    output file path.
- *   --no-killswitch  Skip injecting the kill-switch block and post-embed
- *                    verification run.
  */
 
 declare(strict_types=1);
@@ -82,13 +62,14 @@ if ($positional === []) {
 Embedder - minifies and embeds a PHP class into a target script.
 
 Usage:
-  php embed.php [options] <source-script> [<output-script>]
+  php embed.php [options] <target-script> [<output-script>]
   php embed.php [options] --stdout <output-file>
 
 Arguments:
-  <source-script>   Script containing // @embed-start and // @embed-end markers.
+  <target-script>   Script containing // @embed-start and // @embed-end markers.
                     Modified in place unless <output-script> is provided.
-  <output-script>   Optional output path. Source is copied here before embedding.
+  <output-script>   Optional output path. The target script is copied here
+                    before embedding.
 
 Options:
   --source <path>   Path to the PHP class file to embed. Defaults to Prompty.php
@@ -97,7 +78,7 @@ Options:
                     variables, and reduce whitespace for a smaller output.
   --stdout          Output the processed class as a standalone PHP file instead
                     of embedding into a target script.
-  --no-killswitch   Skip injecting the kill-switch block and post-embed
+  --no-killswitch   Skip injecting the kill switch block and post-embed
                     verification run.
 
 Re-embedding:
@@ -111,21 +92,21 @@ USAGE;
 }
 
 if ($stdout) {
-  // --stdout mode: no source script needed, just an output file.
+  // --stdout mode: no target script needed, just an output file.
   $stdout_path = $positional[0];
 }
 else {
   $input_path = $positional[0];
 
   if (!is_file($input_path)) {
-    fwrite(STDERR, sprintf('Error: Source file not found: %s%s', $input_path, PHP_EOL));
+    fwrite(STDERR, sprintf('Error: Target script not found: %s%s', $input_path, PHP_EOL));
     exit(1);
   }
 
   $target_path = $positional[1] ?? $input_path;
 
   if (isset($positional[1]) && !copy($input_path, $target_path)) {
-    fwrite(STDERR, sprintf('Error: Could not copy source to output: %s%s', $target_path, PHP_EOL));
+    fwrite(STDERR, sprintf('Error: Could not copy target script to output: %s%s', $target_path, PHP_EOL));
     exit(1);
   }
 }

--- a/tests/phpunit/Functional/EmbedScriptTest.php
+++ b/tests/phpunit/Functional/EmbedScriptTest.php
@@ -389,6 +389,17 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->assertProcessFailed();
     $this->assertProcessAnyOutputContains('marker');
 
+    // Target script does not exist.
+    $this->processRun('php', [self::$root . '/embed.php', self::$tmp . '/missing.php']);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('Target script not found');
+
+    // Output path inside a directory that does not exist.
+    $target = $this->prepareTarget();
+    $this->processRun('php', [self::$root . '/embed.php', $target, self::$tmp . '/no-such-dir/output.php']);
+    $this->assertProcessFailed();
+    $this->assertProcessAnyOutputContains('Could not copy target script to output');
+
     // --source without path.
     $this->processRun('php', [self::$root . '/embed.php', '--source']);
     $this->assertProcessFailed();


### PR DESCRIPTION
Closes #46

## Summary

`embed.php` used "source" for 2 opposite things: the positional `<source-script>` argument (the destination script being embedded into) and the `--source` flag (the class file being embedded in). This PR renames the positional argument and its error messages to "target" so every remaining "source" in the script means the class file, and every "target" means the destination. It also folds the usage text down to a single source of truth and normalizes "kill switch" to 2 words in prose, while keeping identifiers and the CLI flag single-word.

## Changes

### Disambiguated source vs target

- Renamed `<source-script>` to `<target-script>` in the nowdoc usage text and the `@file` docblock pointer.
- Changed `Error: Source file not found` to `Error: Target script not found`.
- Changed `Error: Could not copy source to output` to `Error: Could not copy target script to output`.
- Left `Error: Source class not found` and `Error: Could not read source class` alone, since they genuinely describe the `--source` class file, not the positional.
- The `--source` flag itself didn't change, so no existing invocation breaks.

### Consolidated the usage text

- The `$usage` nowdoc is now the single source of truth for the `Usage:`, `Arguments:`, `Options:`, and `Re-embedding:` content.
- The `@file` docblock drops its duplicated `Usage:` and `Options:` blocks in favour of a pointer telling the reader to run the script without arguments.
- The docblock keeps what the nowdoc doesn't carry: the marker requirement, the Rector pass, the kill switch injection, and the post-embed verification run - that's behaviour, not a usage screen, so it stays out of the nowdoc.

### Normalized kill switch prose

- Prose now reads "kill switch" as 2 words consistently in `embed.php` (for example, "A kill switch block is injected").
- Identifiers and the CLI flag stay single-word, since identifiers can't contain spaces: `$no_killswitch`, `$has_killswitch`, `--no-killswitch`, and the `KILLSWITCH` nowdoc label.
- `starter.php` needed no change - its prose already read "kill switch".
- The `KILLSWITCH` nowdoc comment in `embed.php` has to stay byte-identical to the equivalent block in `starter.php`, because `embed.php` locates it by literal string match and a functional test matches it by regex. Both already read "Kill switch", so neither moved; the pair was diffed afterwards to confirm they still match exactly.

### Test coverage

- Added 2 guards to `testEmbedErrors` in `tests/phpunit/Functional/EmbedScriptTest.php`: one asserting `Target script not found` for a missing positional, one asserting `Could not copy target script to output` for an output path in a nonexistent directory.
- Assertion count rose from 826 to 832; test count is unchanged at 342.

Items 2 and 3 moved here from issue #49 while sequencing the work, since both touch the same `@file` docblock region and #46 has to rewrite that text anyway - both issues carry a comment recording the move.

## Screenshots

N/A

## Before / After

The clearest contrast is what "source" meant before versus after.

| Context | Before | After |
|---|---|---|
| Positional argument (the destination being embedded into) | `<source-script>` | `<target-script>` |
| Missing positional error | `Error: Source file not found` | `Error: Target script not found` |
| Copy failure error | `Error: Could not copy source to output` | `Error: Could not copy target script to output` |
| `--source` flag error (the class file being embedded) | `Error: Source class not found` | unchanged |
| `--source` flag read failure | `Error: Could not read source class` | unchanged |

Before, "source" meant 2 opposite things depending on which line you were reading. After, every "source" in `embed.php` means the `--source` class file, and every "target" means the destination script.
