### PR TITLE
[#47] Converged behaviour differences in maintainer tooling.

### DIFF
--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -194,10 +194,10 @@ function main(): void {
   removeDir($tmp_dir);
 
   if (!empty($failed)) {
-    info('');
-    info('Errors:');
+    error('');
+    error('Errors:');
     foreach ($failed as $name => $output) {
-      info('  ' . $name . ': ' . $output);
+      error('  ' . $name . ': ' . $output);
     }
     throw new \RuntimeException('Failed to generate ' . count($failed) . ' asset(s).');
   }
@@ -930,6 +930,18 @@ function info(string $message): void {
   print $message . PHP_EOL;
 }
 
+/**
+ * Print an error message to STDERR.
+ *
+ * Not silenced by SCRIPT_QUIET, so failures surface in quiet runs.
+ *
+ * @param string $message
+ *   The message to print.
+ */
+function error(string $message): void {
+  fwrite(STDERR, $message . PHP_EOL);
+}
+
 ini_set('display_errors', '1');
 
 if (PHP_SAPI !== 'cli' || !empty($_SERVER['REMOTE_ADDR'])) {
@@ -953,7 +965,7 @@ try {
   }
 }
 catch (\Exception $exception) {
-  info('');
-  info('ERROR: ' . $exception->getMessage());
+  error('');
+  error('ERROR: ' . $exception->getMessage());
   exit(1);
 }

--- a/embed.php
+++ b/embed.php
@@ -716,7 +716,7 @@ $final_content = file_get_contents($target_path);
 $final_has_killswitch = $final_content !== FALSE && str_contains($final_content, "if (!getenv('SHOULD_PROCEED'))");
 
 if (!$final_has_killswitch) {
-  echo "\033[33mWarning: No kill switch found in the target file. Please test the embedded script manually.\033[0m" . PHP_EOL;
+  fwrite(STDERR, sprintf('Warning: No kill switch found in the target file. Please test the embedded script manually.%s', PHP_EOL));
 }
 elseif (posix_isatty(STDIN)) {
   echo sprintf('Verifying embedded script (interactive input required)...%s', PHP_EOL);

--- a/embed.php
+++ b/embed.php
@@ -214,7 +214,7 @@ for ($i = 0; $i < $token_count; $i++) {
 }
 
 $lines = explode("\n", $output);
-$lines = array_map(fn(string $line): string => preg_replace('/\s+$/', '', $line) ?? $line, $lines);
+$lines = array_map(fn(string $line): string => rtrim($line), $lines);
 
 $collapsed = array_values(array_filter($lines, fn(string $line): bool => $line !== ''));
 
@@ -228,11 +228,11 @@ while ($i < $line_count) {
 
   if (preg_match('/^\s*(protected|public|private)\s+array\s+\$\w+\s*=\s*\[$/', $line)) {
     $depth = 1;
-    $parts = [preg_replace('/\s+$/', '', $line) ?? $line];
+    $parts = [rtrim($line)];
     $i++;
 
     while ($i < $line_count && $depth > 0) {
-      $inner = preg_replace('/^\s+|\s+$/', '', $collapsed[$i]) ?? $collapsed[$i];
+      $inner = trim($collapsed[$i]);
       // Count only structural brackets (not those inside strings).
       $stripped = preg_replace('/"[^"]*"|\'[^\']*\'/', '', $inner) ?? $inner;
       $depth += substr_count($stripped, '[') - substr_count($stripped, ']');
@@ -263,7 +263,7 @@ foreach ($result_lines as $idx => $result_line) {
 if ($class_start !== NULL) {
   $before_class = array_slice($result_lines, 0, $class_start);
   $class_lines = array_slice($result_lines, $class_start);
-  $class_single = implode(' ', array_map(fn(string $line): string => preg_replace('/^\s+|\s+$/', '', $line) ?? $line, $class_lines));
+  $class_single = implode(' ', array_map(fn(string $line): string => trim($line), $class_lines));
   $result_lines = array_merge($before_class, [$class_single]);
 }
 
@@ -580,7 +580,7 @@ if (preg_match('/^\s*namespace\s+(.+?)\s*;/m', $source, $ns_match)) {
   $namespace = $ns_match[1];
 }
 
-$class_content = preg_replace('/^\s+|\s+$/', '', $minified) . "\n";
+$class_content = trim($minified) . "\n";
 
 $class_content = preg_replace('/^(class\s)/m', "// @phpstan-ignore-next-line\n$1", $class_content, 1);
 
@@ -613,7 +613,7 @@ if (is_file($rector_bin) && is_file($rector_config)) {
     $rector_result = file_get_contents($rector_tmp);
     if ($rector_result !== FALSE) {
       $rector_result = preg_replace('/^<\?php\s+declare\(strict_types\s*=\s*1\)\s*;\s*/s', '', $rector_result);
-      $class_content = preg_replace('/^\s+|\s+$/', '', (string) $rector_result) . "\n";
+      $class_content = trim((string) $rector_result) . "\n";
     }
   }
 

--- a/embed.php
+++ b/embed.php
@@ -214,7 +214,7 @@ for ($i = 0; $i < $token_count; $i++) {
 }
 
 $lines = explode("\n", $output);
-$lines = array_map(fn(string $line): string => rtrim($line), $lines);
+$lines = array_map(rtrim(...), $lines);
 
 $collapsed = array_values(array_filter($lines, fn(string $line): bool => $line !== ''));
 
@@ -263,7 +263,7 @@ foreach ($result_lines as $idx => $result_line) {
 if ($class_start !== NULL) {
   $before_class = array_slice($result_lines, 0, $class_start);
   $class_lines = array_slice($result_lines, $class_start);
-  $class_single = implode(' ', array_map(fn(string $line): string => trim($line), $class_lines));
+  $class_single = implode(' ', array_map(trim(...), $class_lines));
   $result_lines = array_merge($before_class, [$class_single]);
 }
 


### PR DESCRIPTION
Closes #47

## Summary

Converges three behaviour differences in maintainer-facing tooling (`embed.php` and `.util/update-assets.php`) so warning and error output behaves consistently across sites. None of this touches the shipped library - `Prompty.php` is unchanged, and `embed.php` / `.util/update-assets.php` are both build/maintainer tooling, not runtime code consumers depend on.

## Changes

### 1. Warning output unified onto STDERR

`embed.php` had three warning sites split across two channels: one `echo`ed to STDOUT wrapped in a raw `\033[33m` yellow escape, the other two already used `fwrite` to STDERR uncoloured. All three now write uncoloured to STDERR. The coloured site was the outlier on both axes - it emitted its escape unconditionally with no TTY or `NO_COLOR` check, so it corrupted piped output, and `embed.php` emits no other colour anywhere. The `EmbedScriptTest` assertion on `'no kill switch'` was verified (not assumed) to survive: `runEmbedWithOutput()` concatenates `getOutput()` and `getErrorOutput()`, so the assertion is channel-agnostic.

### 2. Native `trim()`/`rtrim()` replacing six `preg_replace()` reimplementations

Six `preg_replace('/^\s+|\s+$/', ...)` / `preg_replace('/\s+$/', ...)` call sites in `embed.php` are replaced with `trim()` / `rtrim()`. The patterns are not *strictly* equivalent to the native calls - PCRE `\s` matches form feed, which `trim()` does not, and `trim()` matches NUL, which PCRE `\s` does not - so each site was checked individually rather than swapped in bulk: all six operate on tokenized PHP source or on Rector's output of it, PHP's lexer treats only space, tab, CR and LF as whitespace so neither divergent character can appear outside a string literal, and `Prompty.php` was confirmed to contain no NUL, vertical-tab or form-feed bytes. Four now-dead `?? $x` null-guards were removed, since `trim()` returns `string` unconditionally where `preg_replace()` returns `string|null`; one `(string)` cast was deliberately kept because it guards a different, still-present `preg_replace()` call. Proof of no behaviour change: `--stdout` and `--compact --stdout` output is byte-identical to a pre-change baseline. A follow-up commit exists because Rector then required first-class callables for two of the delegating closures.

### 3. `.util/update-assets.php` errors routed to STDERR

Every message previously went through `info()`, which prints to STDOUT - including the `ERROR:` line from the top-level catch - while the Node sibling script correctly uses `console.error`. A new `error()` helper writes to STDERR and is now used by the catch block and the `Errors:` summary; the `Done:`/`FAILED:` ticker stays on STDOUT as progress output. `error()` deliberately ignores `SCRIPT_QUIET`: a quiet flag that suppresses error reporting is a trap. The worker protocol was checked against this change: the orchestrator merges each worker's stdout and stderr into one failure string, and an A/B harness replicating that merge produced a byte-identical result before and after.

## Out of scope

Item 4 of issue #47 - unifying `flow()` onto the `setupTty()`/`teardownTty()` helpers - is not in this PR. It moved to issue #57 because it is `Prompty.php`-only, sits entirely in coverage-ignored TTY code that no test can exercise, and its failure mode is a user's terminal left in raw mode. It's being done separately so it can be reviewed and reverted on its own.

A pre-existing bug was found while checking the worker protocol in item 3, and was filed rather than fixed here: issue #58. The orchestrator sets its worker pipes non-blocking and then calls `stream_get_contents()` before `proc_close()`, so a worker still running when the loop reaches it has its output silently dropped - meaning a slow-failing job can be reported with an empty error message. It's channel-independent and predates this work, so it was left alone.

## Testing

`composer lint` clean. `composer test` 342 tests / 832 assertions, unchanged.

## Screenshots

N/A

## Before / After

**Warning channels collapsing onto one** (`embed.php`):

Before:
```php
if (!$final_has_killswitch) {
  echo "\033[33mWarning: No kill switch found in the target file. Please test the embedded script manually.\033[0m" . PHP_EOL;
}
```

After:
```php
if (!$final_has_killswitch) {
  fwrite(STDERR, sprintf('Warning: No kill switch found in the target file. Please test the embedded script manually.%s', PHP_EOL));
}
```

**A `preg_replace` trim reimplementation beside its native equivalent** (`embed.php`):

Before:
```php
$inner = preg_replace('/^\s+|\s+$/', '', $collapsed[$i]) ?? $collapsed[$i];
```

After:
```php
$inner = trim($collapsed[$i]);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Routes all `embed.php` warnings to uncoloured STDERR.
- Replaces six `preg_replace()` trim implementations with native `trim()` and `rtrim()` calls.
- Removes obsolete null guards.
- Routes `.util/update-assets.php` errors to STDERR.
- Keeps progress output on STDOUT.
- Prevents `SCRIPT_QUIET` from suppressing errors.
- Replaces two delegating closures with first-class callables.
- Leaves `Prompty.php` unchanged. The `flow()` TTY-helper work is tracked in `#57`.
- Tracks the pre-existing worker-output issue in `#58`.

## Validation

- `composer lint` passes.
- `composer test` passes with 342 tests and 832 assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->