### PR TITLE
[#57] Unified flow() onto the setupTty and teardownTty helpers.

### DIFF
--- a/Prompty.php
+++ b/Prompty.php
@@ -422,26 +422,19 @@ class Prompty {
       'numbering' => $numbering,
     ];
 
-    // $prev_tty is NULL when no TTY exists (e.g., piped input), and the flow
-    // then runs with env/discovered values without terminal control. An
-    // injected input stream (test mode) also skips TTY setup.
-    $prev_tty = $p->input === NULL ? (shell_exec('stty -g 2>/dev/null') ?: NULL) : NULL;
+    // No TTY exists when input is piped, and the flow then runs with
+    // env/discovered values without terminal control. An injected input
+    // stream (test mode) also skips TTY setup.
+    $p->setupTty();
 
-    if ($prev_tty !== NULL) {
-      $prev_tty = trim($prev_tty);
-      // Disable echo (-echo) and line buffering (-icanon) so each keypress
-      // is available immediately without waiting for Enter.
-      shell_exec('stty -echo -icanon min 1 time 0 2>/dev/null');
-
-      // Restore the terminal even on fatal errors or exceptions.
-      register_shutdown_function(function () use ($p, $prev_tty): void {
+    if ($p->prevTty !== NULL) {
+      // Restore the terminal even on fatal errors or exceptions. teardownTty()
+      // clears prevTty, so this is a no-op once a normal exit path has run.
+      register_shutdown_function(function () use ($p): void {
         // @codeCoverageIgnoreStart
-        $p->restoreTty($prev_tty);
-        $p->showCursor();
+        $p->teardownTty();
         // @codeCoverageIgnoreEnd
       });
-
-      $p->hideCursor();
     }
 
     if ($intro !== NULL) {
@@ -455,12 +448,7 @@ class Prompty {
         is_callable($cancelled) ? $cancelled($p->results) : $p->printLines($p->renderOutro($cancelled));
       }
 
-      if ($prev_tty !== NULL) {
-        // @codeCoverageIgnoreStart
-        $p->restoreTty($prev_tty);
-        $p->showCursor();
-        // @codeCoverageIgnoreEnd
-      }
+      $p->teardownTty();
 
       static::$inFlow = FALSE;
       return NULL;
@@ -470,12 +458,7 @@ class Prompty {
       is_callable($outro) ? $outro($p->results) : $p->printLines($p->renderOutro($outro));
     }
 
-    if ($prev_tty !== NULL) {
-      // @codeCoverageIgnoreStart
-      $p->restoreTty($prev_tty);
-      $p->showCursor();
-      // @codeCoverageIgnoreEnd
-    }
+    $p->teardownTty();
 
     static::$inFlow = FALSE;
     return $p->results;

--- a/Prompty.php
+++ b/Prompty.php
@@ -428,13 +428,13 @@ class Prompty {
     $p->setupTty();
 
     if ($p->prevTty !== NULL) {
+      // @codeCoverageIgnoreStart
       // Restore the terminal even on fatal errors or exceptions. teardownTty()
       // clears prevTty, so this is a no-op once a normal exit path has run.
       register_shutdown_function(function () use ($p): void {
-        // @codeCoverageIgnoreStart
         $p->teardownTty();
-        // @codeCoverageIgnoreEnd
       });
+      // @codeCoverageIgnoreEnd
     }
 
     if ($intro !== NULL) {


### PR DESCRIPTION
Closes #57

## Summary

`Prompty::flow()` inlined the same terminal setup and teardown logic that `setupTty()` and `teardownTty()` already encapsulate for standalone widgets, so the same concept existed in two different shapes. This PR unifies `flow()` onto the shared helpers, removing the duplicated stty/cursor handling and the local `$prev_tty` variable it depended on.

## Changes

- `flow()` now calls `setupTty()` once at the start instead of inlining the `stty -g` capture, the switch to raw mode (`stty -echo -icanon`), and the `hideCursor()` call.
- `flow()` registers `teardownTty()` (rather than a bespoke closure) as the `register_shutdown_function` safety net.
- `flow()` calls `teardownTty()` at both exit points (the cancellation path and the normal completion path) instead of repeating the `restoreTty()` plus `showCursor()` pair inline.
- The `$prev_tty` local is gone entirely; state now lives solely in the `$prevTty` property that `setupTty()` and `teardownTty()` already manage.
- As a side effect, `teardownTty()` nulls `$prevTty` after restoring, so the shutdown closure - which now reads the property instead of capturing a local by value - becomes a genuine no-op on any exit path that already ran a normal teardown, instead of restoring the terminal a second time.

## Verification

**This region is entirely `@codeCoverageIgnore`d - no test exercises it and none can, because it only runs against a real TTY. A green suite proves nothing about this change.** So it was verified directly instead, by driving the library under a real pty with `expect`:

- A scratch harness ran a one-step flow and exited via each of the three paths: normal completion, Ctrl-C mid-prompt, and an uncaught fatal thrown after the flow.
- `stty -g` was captured before and after each run. **All three paths restored the terminal to byte-identical state.**
- The check is not vacuous: the captured trace shows `\033[?25l` on entry and per-keystroke rendering as the answer was typed (`p`, `pr`, `pro`, `prob`, `probe`), which only happens in `-icanon` raw mode. So the terminal genuinely was modified, and genuinely restored.
- **The same three probes were then run against the pre-change code, and its final terminal state is byte-identical to the new code's on every path.** That is behavioural equivalence demonstrated rather than reasoned about.
- All scratch files were removed afterwards.

Gates also green: `composer lint` clean, `composer test` 342 tests / 832 assertions.

This was split out of issue #47 (PR #59, which carries that issue's other three items) precisely because it is the one item where CI tells a reviewer nothing. Keeping it alone means it can be reverted on its own if it ever misbehaves in the wild.

## Screenshots

N/A

## Before / After

**Before**: `flow()` captured `stty -g` into a local `$prev_tty`, called `shell_exec('stty -echo -icanon min 1 time 0 ...')` and `$p->hideCursor()` directly, registered a shutdown closure that captured `$prev_tty` by value and called `$p->restoreTty($prev_tty)` plus `$p->showCursor()`, and repeated that same `restoreTty()` plus `showCursor()` pair inline at both the cancellation and normal exit points - four separate places doing the same two-line restore, with no `$prevTty`-style guard against the shutdown closure running the restore twice.

**After**: `flow()` calls `$p->setupTty()` once, registers `$p->teardownTty()` itself as the shutdown closure, and calls `$p->teardownTty()` at both exit points - the same helpers the standalone widgets already used, with `$prevTty` nulled after each teardown so the shutdown net cannot double-restore.
