### PR TITLE
[#58] Drained worker pipes to EOF before closing them.

### DIFF
--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -170,15 +170,14 @@ function main(): void {
 
   $failed = [];
   foreach ($processes as $name => $process) {
-    $stdout = stream_get_contents($pipes_list[$name][1]);
-    $stderr = stream_get_contents($pipes_list[$name][2]);
+    [$stdout, $stderr] = drainPipes($pipes_list[$name][1], $pipes_list[$name][2]);
     fclose($pipes_list[$name][1]);
     fclose($pipes_list[$name][2]);
 
     $exit_code = proc_close($process);
 
     if ($exit_code !== 0) {
-      $failed[$name] = trim(($stdout ?: '') . ($stderr ?: ''));
+      $failed[$name] = trim($stdout . $stderr);
       info('  FAILED: ' . $name);
     }
     else {
@@ -900,6 +899,59 @@ EXPECT;
 
   file_put_contents($expect_script, $content);
   chmod($expect_script, 0700);
+}
+
+/**
+ * Read a worker's stdout and stderr until both reach EOF.
+ *
+ * Both pipes are polled together rather than read one after the other, so a
+ * worker that fills one pipe buffer cannot block while this waits on the
+ * other. Returns only once the worker has closed both ends, which is what
+ * makes the captured output complete enough to diagnose a failure.
+ *
+ * @param resource $stdout_pipe
+ *   The worker's stdout pipe.
+ * @param resource $stderr_pipe
+ *   The worker's stderr pipe.
+ *
+ * @return array{0: string, 1: string}
+ *   The captured stdout and stderr.
+ */
+function drainPipes($stdout_pipe, $stderr_pipe): array {
+  $stdout = '';
+  $stderr = '';
+  $open = [$stdout_pipe, $stderr_pipe];
+
+  while ($open !== []) {
+    $read = $open;
+    $write = NULL;
+    $except = NULL;
+
+    if (stream_select($read, $write, $except, NULL) === FALSE) {
+      break;
+    }
+
+    foreach ($read as $stream) {
+      $chunk = fread($stream, 8192);
+
+      if ($chunk === FALSE || $chunk === '') {
+        if (feof($stream)) {
+          $open = array_values(array_filter($open, fn($candidate): bool => $candidate !== $stream));
+        }
+
+        continue;
+      }
+
+      if ($stream === $stdout_pipe) {
+        $stdout .= $chunk;
+      }
+      else {
+        $stderr .= $chunk;
+      }
+    }
+  }
+
+  return [$stdout, $stderr];
 }
 
 /**


### PR DESCRIPTION
Closes #58

## Summary

`.util/update-assets.php` runs each maintainer asset-generation job as a parallel worker, then drains its stdout/stderr pipes with a single non-blocking `stream_get_contents()` call before closing them and calling `proc_close()` — this reads whatever happens to be buffered at that instant rather than waiting for the worker to finish, so a still-running worker can have its pipes closed out from under it, and this PR replaces that read with a `drainPipes()` helper that polls both pipes with `stream_select()` until each reaches EOF.

## Changes

- Added `drainPipes(resource $stdout_pipe, resource $stderr_pipe): array` to `.util/update-assets.php`, which loops on `stream_select()` over both pipes together and accumulates `fread()` chunks into `$stdout` / `$stderr` until both streams report `feof()`.
- Replaced the two-line `stream_get_contents()` read in `main()`'s drain loop with a single call to `drainPipes()`, keeping `fclose()` and `proc_close()` unchanged and running after the drain completes.
- Simplified the failure-message assembly from `trim(($stdout ?: '') . ($stderr ?: ''))` to `trim($stdout . $stderr)` since `drainPipes()` always returns strings, never `false`.

## Verification

`.util/` sits outside the phpcs, phpstan and PHPUnit paths configured for this repo, so the existing suite cannot exercise this code — the evidence here is a standalone proof harness that replicates the orchestrator's exact spawn-and-read pattern against a worker that fails after a 400ms delay:

```
old: exit=255 captured=[]
new: exit=1   captured=[SLOW FAILURE MESSAGE]
```

That single run surfaces two independent defects in the old code, not one: the captured diagnostic was empty, and since that string is the only thing ever reported for a failed job, the maintainer received a failure with no explanation; separately, the exit code was wrong, because closing the pipes while the worker was still running caused its later write to land on a closed pipe, killing it with `SIGPIPE` (exit 255) instead of letting it exit 1 as intended — the old code did not merely lose the message, it killed the worker and then misreported why it died.

The `stream_select()` polling was chosen specifically to avoid a deadlock a naive sequential read would hit — reading stdout to completion first would block forever against a worker that fills the stderr pipe buffer while waiting for stdout to be drained — and this was tested explicitly with a worker that writes 300000 bytes to both streams, comfortably past the OS pipe buffer on any platform:

```
completed in 0.07s, captured 600000 bytes total, exit code correct
```

The real script's error path was also exercised end to end: `php .util/update-assets.php --record bogus-job` still prints `ERROR: Unknown job: bogus-job` to STDERR and exits 1.

Gates are green regardless of the `.util/` coverage gap: `composer lint` is clean, and `composer test` passes 342 tests / 832 assertions.

## Screenshots

N/A

## Before / After

**Before**: the drain loop called `stream_get_contents()` once per pipe immediately after the non-blocking worker was launched, so it captured only whatever bytes happened to already be buffered — for a worker still writing, that was frequently nothing — and then closed both pipes and called `proc_close()`, which is where the code actually waited for the worker to exit; if the worker was still writing when its pipe was closed, the write raised `SIGPIPE` and the worker died with exit 255 instead of its intended exit code.

**After**: `drainPipes()` runs before any pipe is closed, and loops on `stream_select()` over both the stdout and stderr pipes together, reading whichever one has data ready and tracking each pipe's EOF independently, so it only returns once the worker has finished writing and closed both ends on its side — `fclose()` and `proc_close()` then run against pipes that are already fully drained, so the worker is never killed mid-write.

**Outcome**: the 400ms-delayed-failure proof harness moves from `exit=255 captured=[]` (worker killed by `SIGPIPE`, no diagnostic) to `exit=1 captured=[SLOW FAILURE MESSAGE]` (worker exits as intended, full diagnostic captured) — both defects are fixed by the same change, because they shared the same root cause of reading before the worker was done.
