### PR TITLE
[#48] Settled four remaining naming and structure ties.

### DIFF
--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -134,7 +134,7 @@ function main(): void {
   foreach ($jobs as $name => $job) {
     $expect_script = $tmp_dir . '/' . $name . '.exp';
     $create_fn = $job['expect_fn'];
-    $create_fn($expect_script, $job['script']);
+    $create_fn($job['script'], $expect_script);
   }
 
   $script_path = __FILE__;
@@ -231,7 +231,7 @@ function processOne(string $name): void {
   $cols = $job['cols'] ?? TERMINAL_COLS;
   $at = $job['at'] ?? NULL;
 
-  recordSession($cast_file, $expect_script, $rows, $cols);
+  recordSession($expect_script, $cast_file, $rows, $cols);
   postProcessCast($cast_file);
   convertToSvg($cast_file, $svg_file, $script_dir, $at);
 }
@@ -285,16 +285,16 @@ function installNodeDependencies(string $script_dir): void {
 /**
  * Record a session using asciinema with an expect script.
  *
- * @param string $cast_file
- *   Path to write the cast file.
  * @param string $expect_script
  *   Path to the expect script for automation.
+ * @param string $cast_file
+ *   Path to write the cast file.
  * @param int $rows
  *   Number of terminal rows.
  * @param int $cols
  *   Number of terminal columns.
  */
-function recordSession(string $cast_file, string $expect_script, int $rows = TERMINAL_ROWS, int $cols = TERMINAL_COLS): void {
+function recordSession(string $expect_script, string $cast_file, int $rows = TERMINAL_ROWS, int $cols = TERMINAL_COLS): void {
   $cmd = sprintf(
     'asciinema rec --command=%s --window-size=%dx%d --idle-time-limit=%d --overwrite %s 2>&1',
     escapeshellarg($expect_script),
@@ -381,12 +381,12 @@ function convertToSvg(string $cast_file, string $svg_file, string $script_dir, ?
 /**
  * Create an expect script for the widgets.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createWidgetsExpectScript(string $expect_script, string $playground_script): void {
+function createWidgetsExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -463,12 +463,12 @@ EXPECT;
 /**
  * Create an expect script for the flow.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createFlowExpectScript(string $expect_script, string $playground_script): void {
+function createFlowExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -546,12 +546,12 @@ EXPECT;
 /**
  * Create an expect script for the flow-nested.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createFlowNestedExpectScript(string $expect_script, string $playground_script): void {
+function createFlowNestedExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -668,12 +668,12 @@ EXPECT;
 /**
  * Create an expect script for the widget-text.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createWidgetTextExpectScript(string $expect_script, string $playground_script): void {
+function createWidgetTextExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -730,12 +730,12 @@ EXPECT;
 /**
  * Create an expect script for the widget-select.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createWidgetSelectExpectScript(string $expect_script, string $playground_script): void {
+function createWidgetSelectExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -781,12 +781,12 @@ EXPECT;
 /**
  * Create an expect script for the widget-multiselect.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createWidgetMultiselectExpectScript(string $expect_script, string $playground_script): void {
+function createWidgetMultiselectExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect
@@ -843,12 +843,12 @@ EXPECT;
 /**
  * Create an expect script for the widget-confirm.php playground.
  *
- * @param string $expect_script
- *   Path to write the expect script.
  * @param string $playground_script
  *   Path to the playground PHP script.
+ * @param string $expect_script
+ *   Path to write the expect script.
  */
-function createWidgetConfirmExpectScript(string $expect_script, string $playground_script): void {
+function createWidgetConfirmExpectScript(string $playground_script, string $expect_script): void {
   $delay = PROMPT_DELAY;
   $content = <<<EXPECT
 #!/usr/bin/env expect

--- a/Prompty.php
+++ b/Prompty.php
@@ -1284,40 +1284,6 @@ class Prompty {
   }
 
   /**
-   * Renders the intro banner lines.
-   *
-   * @param string $message
-   *   The intro message to display.
-   *
-   * @return array<int, string>
-   *   The rendered intro lines.
-   */
-  protected function renderIntro(string $message): array {
-    return [
-      '',
-      $this->color($this->cfgSymbols['intro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'bold'),
-      $this->bar(),
-    ];
-  }
-
-  /**
-   * Renders the outro banner lines.
-   *
-   * @param string $message
-   *   The outro message to display.
-   *
-   * @return array<int, string>
-   *   The rendered outro lines.
-   */
-  protected function renderOutro(string $message): array {
-    return [
-      $this->bar(),
-      $this->color($this->cfgSymbols['outro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'green'),
-      '',
-    ];
-  }
-
-  /**
    * Clears previously printed lines and redraws with new content.
    *
    * @param int $prev_line_count
@@ -1378,6 +1344,60 @@ class Prompty {
   }
 
   /**
+   * Appends a step number suffix to a label when numbering is enabled.
+   *
+   * @param string $label
+   *   The original label text.
+   * @param array<string, mixed> $ctx
+   *   Flow context.
+   *
+   * @return string
+   *   The label with an optional step number suffix.
+   */
+  protected function numberLabel(string $label, array $ctx): string {
+    if (isset($ctx['number'])) {
+      /** @var string $number */
+      $number = $ctx['number'];
+      return $label . ' ' . $this->color('(' . $number . ')', 'dim');
+    }
+    return $label;
+  }
+
+  /**
+   * Renders the intro banner lines.
+   *
+   * @param string $message
+   *   The intro message to display.
+   *
+   * @return array<int, string>
+   *   The rendered intro lines.
+   */
+  protected function renderIntro(string $message): array {
+    return [
+      '',
+      $this->color($this->cfgSymbols['intro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'bold'),
+      $this->bar(),
+    ];
+  }
+
+  /**
+   * Renders the outro banner lines.
+   *
+   * @param string $message
+   *   The outro message to display.
+   *
+   * @return array<int, string>
+   *   The rendered outro lines.
+   */
+  protected function renderOutro(string $message): array {
+    return [
+      $this->bar(),
+      $this->color($this->cfgSymbols['outro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'green'),
+      '',
+    ];
+  }
+
+  /**
    * Renders description text lines with appropriate depth indentation.
    *
    * @param string $description
@@ -1428,26 +1448,6 @@ class Prompty {
       $hint_lines,
       array_keys($hint_lines),
     );
-  }
-
-  /**
-   * Appends a step number suffix to a label when numbering is enabled.
-   *
-   * @param string $label
-   *   The original label text.
-   * @param array<string, mixed> $ctx
-   *   Flow context.
-   *
-   * @return string
-   *   The label with an optional step number suffix.
-   */
-  protected function numberLabel(string $label, array $ctx): string {
-    if (isset($ctx['number'])) {
-      /** @var string $number */
-      $number = $ctx['number'];
-      return $label . ' ' . $this->color('(' . $number . ')', 'dim');
-    }
-    return $label;
   }
 
   /**

--- a/embed.php
+++ b/embed.php
@@ -111,17 +111,17 @@ else {
   }
 }
 
-$embed_source = $source_override ?? EMBED_SOURCE;
+$source_path = $source_override ?? EMBED_SOURCE;
 
-if (!is_file($embed_source)) {
-  fwrite(STDERR, sprintf('Error: Source class not found: %s%s', $embed_source, PHP_EOL));
+if (!is_file($source_path)) {
+  fwrite(STDERR, sprintf('Error: Source class not found: %s%s', $source_path, PHP_EOL));
   exit(1);
 }
 
-$source = file_get_contents($embed_source);
+$source = file_get_contents($source_path);
 
 if ($source === FALSE) {
-  fwrite(STDERR, sprintf('Error: Could not read source class: %s%s', $embed_source, PHP_EOL));
+  fwrite(STDERR, sprintf('Error: Could not read source class: %s%s', $source_path, PHP_EOL));
   exit(1);
 }
 
@@ -276,8 +276,8 @@ if ($compact && $class_start !== NULL) {
 
   // Wrap in <?php for tokenization.
   $php_code = '<?php ' . $class_line;
-  $ctokens = token_get_all($php_code);
-  $ctokens_count = count($ctokens);
+  $compact_tokens = token_get_all($php_code);
+  $compact_token_count = count($compact_tokens);
 
   // --- Step 1: Collect protected/private property and method names. ---
   $protected_props = [];
@@ -287,12 +287,12 @@ if ($compact && $class_start !== NULL) {
   $visibility = NULL;
   $is_static = FALSE;
 
-  for ($i = 0; $i < $ctokens_count; $i++) {
-    if (!is_array($ctokens[$i])) {
+  for ($i = 0; $i < $compact_token_count; $i++) {
+    if (!is_array($compact_tokens[$i])) {
       continue;
     }
 
-    $token_type = $ctokens[$i][0];
+    $token_type = $compact_tokens[$i][0];
 
     if ($token_type === T_PUBLIC) {
       $visibility = 'public';
@@ -312,16 +312,16 @@ if ($compact && $class_start !== NULL) {
     }
 
     if ($token_type === T_VARIABLE && $visibility !== NULL) {
-      $prop_name = substr($ctokens[$i][1], 1);
+      $prop_name = substr($compact_tokens[$i][1], 1);
 
       // Treat as a property unless the preceding non-whitespace token is
       // T_FUNCTION.
       $is_property = TRUE;
       for ($k = $i - 1; $k >= 0; $k--) {
-        if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
+        if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_WHITESPACE) {
           continue;
         }
-        if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_FUNCTION) {
+        if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_FUNCTION) {
           $is_property = FALSE;
         }
         break;
@@ -336,12 +336,12 @@ if ($compact && $class_start !== NULL) {
     }
 
     if ($token_type === T_FUNCTION) {
-      for ($k = $i + 1; $k < $ctokens_count; $k++) {
-        if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
+      for ($k = $i + 1; $k < $compact_token_count; $k++) {
+        if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_WHITESPACE) {
           continue;
         }
-        if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_STRING) {
-          $method_name = $ctokens[$k][1];
+        if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_STRING) {
+          $method_name = $compact_tokens[$k][1];
 
           if (!str_starts_with($method_name, '__')) {
             if ($visibility !== 'public') {
@@ -349,18 +349,18 @@ if ($compact && $class_start !== NULL) {
             }
             else {
               $paren_depth = 0;
-              for ($m = $k + 1; $m < $ctokens_count; $m++) {
-                if (is_string($ctokens[$m]) && $ctokens[$m] === '(') {
+              for ($m = $k + 1; $m < $compact_token_count; $m++) {
+                if (is_string($compact_tokens[$m]) && $compact_tokens[$m] === '(') {
                   $paren_depth++;
                 }
-                elseif (is_string($ctokens[$m]) && $ctokens[$m] === ')') {
+                elseif (is_string($compact_tokens[$m]) && $compact_tokens[$m] === ')') {
                   $paren_depth--;
                   if ($paren_depth <= 0) {
                     break;
                   }
                 }
-                elseif (is_array($ctokens[$m]) && $ctokens[$m][0] === T_VARIABLE && $paren_depth > 0) {
-                  $public_method_params[substr($ctokens[$m][1], 1)] = TRUE;
+                elseif (is_array($compact_tokens[$m]) && $compact_tokens[$m][0] === T_VARIABLE && $paren_depth > 0) {
+                  $public_method_params[substr($compact_tokens[$m][1], 1)] = TRUE;
                 }
               }
             }
@@ -374,7 +374,7 @@ if ($compact && $class_start !== NULL) {
     }
 
     // Reset visibility on any unexpected token.
-    if (!in_array($token_type, [T_WHITESPACE, T_STRING, T_ARRAY, T_NS_SEPARATOR], TRUE) && $ctokens[$i][1] !== '?') {
+    if (!in_array($token_type, [T_WHITESPACE, T_STRING, T_ARRAY, T_NS_SEPARATOR], TRUE) && $compact_tokens[$i][1] !== '?') {
       $visibility = NULL;
       $is_static = FALSE;
     }
@@ -401,14 +401,14 @@ if ($compact && $class_start !== NULL) {
   ];
 
   $all_vars = [];
-  for ($i = 0; $i < $ctokens_count; $i++) {
-    if (!is_array($ctokens[$i])) {
+  for ($i = 0; $i < $compact_token_count; $i++) {
+    if (!is_array($compact_tokens[$i])) {
       continue;
     }
-    if ($ctokens[$i][0] !== T_VARIABLE) {
+    if ($compact_tokens[$i][0] !== T_VARIABLE) {
       continue;
     }
-    $var_name = substr($ctokens[$i][1], 1);
+    $var_name = substr($compact_tokens[$i][1], 1);
 
     if (in_array($var_name, $superglobals, TRUE)) {
       continue;
@@ -443,14 +443,14 @@ if ($compact && $class_start !== NULL) {
   // --- Step 3: Apply renames via token walk. ---
   $compact_output = '';
 
-  for ($i = 1; $i < $ctokens_count; $i++) {
-    if (is_string($ctokens[$i])) {
-      $compact_output .= $ctokens[$i];
+  for ($i = 1; $i < $compact_token_count; $i++) {
+    if (is_string($compact_tokens[$i])) {
+      $compact_output .= $compact_tokens[$i];
       continue;
     }
 
-    $token_type = $ctokens[$i][0];
-    $token_value = $ctokens[$i][1];
+    $token_type = $compact_tokens[$i][0];
+    $token_value = $compact_tokens[$i][1];
 
     if ($token_type === T_VARIABLE) {
       $var_name = substr($token_value, 1);
@@ -475,20 +475,20 @@ if ($compact && $class_start !== NULL) {
     if ($token_type === T_STRING) {
       $prev = NULL;
       for ($k = $i - 1; $k >= 0; $k--) {
-        if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
+        if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_WHITESPACE) {
           continue;
         }
-        $prev = is_array($ctokens[$k]) ? $ctokens[$k][0] : $ctokens[$k];
+        $prev = is_array($compact_tokens[$k]) ? $compact_tokens[$k][0] : $compact_tokens[$k];
         break;
       }
 
       if ($prev === T_OBJECT_OPERATOR || $prev === T_NULLSAFE_OBJECT_OPERATOR) {
         $next = NULL;
-        for ($k = $i + 1; $k < $ctokens_count; $k++) {
-          if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
+        for ($k = $i + 1; $k < $compact_token_count; $k++) {
+          if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_WHITESPACE) {
             continue;
           }
-          $next = is_array($ctokens[$k]) ? $ctokens[$k][1] : $ctokens[$k];
+          $next = is_array($compact_tokens[$k]) ? $compact_tokens[$k][1] : $compact_tokens[$k];
           break;
         }
 
@@ -505,11 +505,11 @@ if ($compact && $class_start !== NULL) {
 
       if ($prev === T_DOUBLE_COLON && isset($method_map[$token_value])) {
         $next = NULL;
-        for ($k = $i + 1; $k < $ctokens_count; $k++) {
-          if (is_array($ctokens[$k]) && $ctokens[$k][0] === T_WHITESPACE) {
+        for ($k = $i + 1; $k < $compact_token_count; $k++) {
+          if (is_array($compact_tokens[$k]) && $compact_tokens[$k][0] === T_WHITESPACE) {
             continue;
           }
-          $next = is_array($ctokens[$k]) ? $ctokens[$k][1] : $ctokens[$k];
+          $next = is_array($compact_tokens[$k]) ? $compact_tokens[$k][1] : $compact_tokens[$k];
           break;
         }
         if ($next === '(') {
@@ -533,24 +533,24 @@ if ($compact && $class_start !== NULL) {
   // --- Step 4: Reduce whitespace. ---
   // Remove spaces around operators where PHP allows it.
   // Works on tokens so string contents are not modified.
-  $ws_tokens = token_get_all('<?php ' . $compact_output);
-  $ws_count = count($ws_tokens);
-  $ws_output = '';
+  $whitespace_tokens = token_get_all('<?php ' . $compact_output);
+  $whitespace_token_count = count($whitespace_tokens);
+  $whitespace_output = '';
 
-  for ($i = 1; $i < $ws_count; $i++) {
-    if (!is_array($ws_tokens[$i])) {
-      $ws_output .= $ws_tokens[$i];
+  for ($i = 1; $i < $whitespace_token_count; $i++) {
+    if (!is_array($whitespace_tokens[$i])) {
+      $whitespace_output .= $whitespace_tokens[$i];
       continue;
     }
 
-    $token_type = $ws_tokens[$i][0];
-    $token_value = $ws_tokens[$i][1];
+    $token_type = $whitespace_tokens[$i][0];
+    $token_value = $whitespace_tokens[$i][1];
 
     if ($token_type === T_WHITESPACE) {
-      $before = is_array($ws_tokens[$i - 1]) ? $ws_tokens[$i - 1][1] : $ws_tokens[$i - 1];
+      $before = is_array($whitespace_tokens[$i - 1]) ? $whitespace_tokens[$i - 1][1] : $whitespace_tokens[$i - 1];
       $after = '';
-      if ($i + 1 < $ws_count) {
-        $after = is_array($ws_tokens[$i + 1]) ? $ws_tokens[$i + 1][1] : $ws_tokens[$i + 1];
+      if ($i + 1 < $whitespace_token_count) {
+        $after = is_array($whitespace_tokens[$i + 1]) ? $whitespace_tokens[$i + 1][1] : $whitespace_tokens[$i + 1];
       }
 
       // Remove the space when either neighbour is a non-word character.
@@ -562,16 +562,16 @@ if ($compact && $class_start !== NULL) {
 
       if ($before_is_word && $after_is_word) {
         // Space is needed between two word characters.
-        $ws_output .= ' ';
+        $whitespace_output .= ' ';
       }
       continue;
     }
 
-    $ws_output .= $token_value;
+    $whitespace_output .= $token_value;
   }
 
   $result_lines = $before_class;
-  $result_lines[] = $ws_output;
+  $result_lines[] = $whitespace_output;
   $minified = implode("\n", $result_lines);
 }
 
@@ -580,9 +580,9 @@ if (preg_match('/^\s*namespace\s+(.+?)\s*;/m', $source, $ns_match)) {
   $namespace = $ns_match[1];
 }
 
-$class_content = trim($minified) . "\n";
+$payload = trim($minified) . "\n";
 
-$class_content = preg_replace('/^(class\s)/m', "// @phpstan-ignore-next-line\n$1", $class_content, 1);
+$payload = preg_replace('/^(class\s)/m', "// @phpstan-ignore-next-line\n$1", $payload, 1);
 
 // Run Rector on the processed class content if available.
 $rector_bin = __DIR__ . '/vendor/bin/rector';
@@ -598,7 +598,7 @@ if (is_file($rector_bin) && is_file($rector_config)) {
   $rector_tmp .= '.php';
 
   // Wrap class content in a valid PHP file for rector.
-  $rector_input = "<?php\n\ndeclare(strict_types=1);\n\n" . $class_content;
+  $rector_input = "<?php\n\ndeclare(strict_types=1);\n\n" . $payload;
   file_put_contents($rector_tmp, $rector_input);
 
   $rector_output = [];
@@ -613,7 +613,7 @@ if (is_file($rector_bin) && is_file($rector_config)) {
     $rector_result = file_get_contents($rector_tmp);
     if ($rector_result !== FALSE) {
       $rector_result = preg_replace('/^<\?php\s+declare\(strict_types\s*=\s*1\)\s*;\s*/s', '', $rector_result);
-      $class_content = trim((string) $rector_result) . "\n";
+      $payload = trim((string) $rector_result) . "\n";
     }
   }
 
@@ -627,7 +627,7 @@ if ($stdout) {
   if ($namespace !== '') {
     $standalone .= "namespace {$namespace};\n\n";
   }
-  $standalone .= $class_content;
+  $standalone .= $payload;
 
   file_put_contents($stdout_path, $standalone);
 
@@ -647,7 +647,7 @@ if ($stdout) {
 
 // Build and inject the embedded block.
 $embedded = '// ' . EMBED_MARKER_START . "\n";
-$embedded .= $class_content;
+$embedded .= $payload;
 $embedded .= '// ' . EMBED_MARKER_END;
 
 $target = file_get_contents($target_path);
@@ -712,8 +712,8 @@ if ($lint_exit !== 0) {
 
 echo sprintf('Embedded into %s%s', $target_path, PHP_EOL);
 
-$final_content = file_get_contents($target_path);
-$final_has_killswitch = $final_content !== FALSE && str_contains($final_content, "if (!getenv('SHOULD_PROCEED'))");
+$final = file_get_contents($target_path);
+$final_has_killswitch = $final !== FALSE && str_contains($final, "if (!getenv('SHOULD_PROCEED'))");
 
 if (!$final_has_killswitch) {
   fwrite(STDERR, sprintf('Warning: No kill switch found in the target file. Please test the embedded script manually.%s', PHP_EOL));

--- a/tests/phpunit/Functional/EmbedScriptTest.php
+++ b/tests/phpunit/Functional/EmbedScriptTest.php
@@ -382,7 +382,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->assertProcessAnyOutputContains('Usage');
 
     // Missing markers.
-    $target = self::$tmp . '/no-markers.php';
+    $target = self::$tmp . '/target.no-markers.php';
     file_put_contents($target, "<?php\necho 'hello';\n");
 
     $this->processRun('php', [self::$root . '/embed.php', $target]);
@@ -453,7 +453,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $content = preg_replace('/\/\/ Kill switch.*?if \(!getenv\(\'SHOULD_PROCEED\'\)\) \{\s*return;\s*\}\n*/s', '', $content);
     $this->assertIsString($content);
 
-    $target = self::$tmp . '/starter_no_ks.php';
+    $target = self::$tmp . '/starter.no-killswitch.php';
     file_put_contents($target, $content);
 
     return $target;


### PR DESCRIPTION
Closes #48

## Summary
An earlier convergence pass identified four naming and structure splits and deferred all four because none had a project rule, a clear majority, or a decisive idiom to point at. This PR picks a canonical form for each by ecosystem idiom, with the reasoning recorded per item below. Zero behaviour change anywhere - every commit is a pure rename or relocation.

## Changes

### 1. `embed.php` naming (`7e522e5`)
Three splits, each decided on principle rather than tally.
- **File-content strings** converged on bare stage/role nouns, the file's own dominant idiom: `$class_content` became `$payload`, `$final_content` became `$final`. `$rector_input`/`$rector_result` were deliberately kept as-is - their sub-process qualifier is load-bearing, because `$result` and `$rector_output` already claim the bare names, so they read as stage nouns rather than a third competing scheme.
- **Path suffix**: the raw 3:5 majority was rejected. The `_path` suffix is disambiguation, not decoration - `$target` and `$stdout` are already claimed by a content string and a flag, so dropping the suffix would collide. It was kept on the three sites that already had it and added where the same ambiguity existed, with `$embed_source` becoming `$source_path`. Role-worded paths that carry no ambiguity (`rector_bin`, `rector_config`, `rector_tmp`, `source_override`) stay bare. The convergence is on the principle, not the count.
- **Token-walk families** now use full-word pass qualifiers, with the primary pass left unqualified: `$ctokens`/`$ctokens_count` became `$compact_tokens`/`$compact_token_count`, matching the existing `$compact`/`$compact_output` family; `$ws_*` became `$whitespace_*`. 62 lines changed in total, and every new name was confirmed unused beforehand so nothing shadows in that single procedural scope.

### 2. `.util/update-assets.php` argument order (`ab73ce0`)
Converged on input-first, following PHP's own `copy()` and `rename()` and the shell `cp src dst`. The raw 8:1 count favoured output-first, but seven of those eight are one cloned decision replicated across near-identical creator functions; discounted, it is roughly 2:1 against the conventional idiom. `recordSession()` and the seven `create*ExpectScript()` functions now take the source first and the written file last. 16 declaration sites (signature plus docblock, per function) and 2 call sites updated; the emitted expect scripts are byte-identical.

### 3. Functional temp fixtures (`4f0ae5c`)
Converged on the coherent dot-variant scheme `<base>.<variant>.php`, matching the established `Prompty.min.php`/`Prompty.compact.php`/`Prompty.source.php` family. `starter_no_ks.php` became `starter.no-killswitch.php` (named after the `--no-killswitch` flag it exercises) and `no-markers.php` became `target.no-markers.php`. 2 sites.

### 4. `Prompty.php` render-helper grouping (`2ada3f4`)
Flagged as the most easily skipped of the four, since it produces a large diff for zero functional change - "the current order roughly follows the call graph" was the argument for leaving it alone. That claim was checked and did not hold: `numberLabel` precedes `renderCompleted`/`renderCancelled` but is never called by them, and `redraw` - which only widget code calls - split the render family in two. The existing order carried no information worth preserving, so the methods were grouped as `printLines`, `redraw`, `labelPrefix`, `bodyPrefix`, `numberLabel`, then a contiguous six-method `render*` block, with dependencies still preceding dependents. Pure relocation, verified by a sorted-line comparison against the base being byte-identical.

## Verification
- `embed.php`'s renames are output-neutral, proven byte-for-byte: running `--stdout` and `--compact --stdout` with the new `embed.php` against the unchanged `Prompty.php` produces byte-identical output to the base in both modes. That isolation matters - a naive before/after comparison shows a difference, but it comes entirely from item 4 reordering `Prompty.php`'s methods, which is the very content being embedded, and in compact mode also shifts which short name each method receives. Semantically identical, and `EmbedScriptTest` executes the embedded output, so it is verified working.
- All seven generated expect scripts are byte-identical before and after item 2.
- `composer lint` clean; `composer test` green at 342 tests / 832 assertions, unchanged.

## Screenshots
N/A

## Before / After
The clearest contrast is the three competing token-walk families in `embed.php` collapsing into one qualifier scheme.

Before - three ad hoc names for three token arrays, none sharing a convention:
```php
$ctokens = token_get_all($php_code);
$ctokens_count = count($ctokens);
// ...
$ws_tokens = token_get_all('<?php ' . $compact_output);
$ws_count = count($ws_tokens);
$ws_output = '';
```

After - each pass qualified by full word, matching the primary pass's own `tokens`/`token_count` shape:
```php
$compact_tokens = token_get_all($php_code);
$compact_token_count = count($compact_tokens);
// ...
$whitespace_tokens = token_get_all('<?php ' . $compact_output);
$whitespace_token_count = count($whitespace_tokens);
$whitespace_output = '';
```
