### PR TITLE
[#64] Made 'playground' demos PHPStan-clean and added them to quality tool targets.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
   paths:
     - Prompty.php
     - PromptyTestTrait.php
+    - playground
     - embed.php
     - starter.php
     - tests/phpunit

--- a/playground/flow-multiple.php
+++ b/playground/flow-multiple.php
@@ -32,10 +32,12 @@ if ($basics === NULL) {
   exit(0);
 }
 
-echo "\nOrder: " . $basics['dish'] . ' + ' . $basics['course'] . "\n\n";
+$dish = is_string($basics['dish']) ? $basics['dish'] : '';
+$course = is_string($basics['course']) ? $basics['course'] : '';
+echo "\nOrder: " . $dish . ' + ' . $course . "\n\n";
 
 $extra = Prompty::text('Kitchen note', placeholder: 'no onions');
-echo 'Note: ' . ($extra ?? 'cancelled') . "\n\n";
+echo 'Note: ' . (is_string($extra) ? $extra : 'cancelled') . "\n\n";
 
 $options = Prompty::flow(fn(): array => [
   'extras' => Prompty::multiselect('Extras', options: ['bread' => 'Bread', 'olives' => 'Olives', 'herbs' => 'Herbs']),
@@ -50,5 +52,6 @@ if ($options === NULL) {
   exit(0);
 }
 
-echo "\nExtras: " . (count($options['extras']) > 0 ? implode(', ', $options['extras']) : 'none') . "\n";
+$extras = is_array($options['extras']) ? $options['extras'] : [];
+echo "\nExtras: " . ($extras === [] ? 'none' : implode(', ', $extras)) . "\n";
 echo 'Send: ' . ($options['send'] ? 'yes' : 'no') . "\n";

--- a/playground/flow-nested.php
+++ b/playground/flow-nested.php
@@ -15,21 +15,6 @@ $opts = getopt('', ['no-unicode', 'no-ansi']);
 $unicode = !isset($opts['no-unicode']);
 $ansi = !isset($opts['no-ansi']);
 
-/**
- * Prints the collected answers once the flow completes.
- *
- * @param array<string, string|bool|int|array<string, string>> $results
- *   Values collected by the flow, keyed by step name.
- */
-function print_order_summary(array $results): void {
-  Prompty::outro('Order sent to the kitchen!');
-  echo "\nCollected answers:\n";
-  foreach ($results as $key => $value) {
-    $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
-    echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
-  }
-}
-
 $results = Prompty::flow(fn(): array => [
   'course' => Prompty::select('Course',
     options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert'],
@@ -153,7 +138,14 @@ $results = Prompty::flow(fn(): array => [
   ),
 ],
   intro: 'Kitchen order',
-  outro: print_order_summary(...),
+  outro: function (array $results): void {
+    Prompty::outro('Order sent to the kitchen!');
+    echo "\nCollected answers:\n";
+    foreach ($results as $key => $value) {
+      $display = is_array($value) ? (count($value) > 0 ? implode(', ', array_filter($value, is_string(...))) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
+      echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
+    }
+  },
   cancelled: 'Kitchen order cancelled.',
   numbering: TRUE,
   unicode: $unicode,

--- a/playground/flow-nested.php
+++ b/playground/flow-nested.php
@@ -15,6 +15,21 @@ $opts = getopt('', ['no-unicode', 'no-ansi']);
 $unicode = !isset($opts['no-unicode']);
 $ansi = !isset($opts['no-ansi']);
 
+/**
+ * Prints the collected answers once the flow completes.
+ *
+ * @param array<string, string|bool|int|array<string, string>> $results
+ *   Values collected by the flow, keyed by step name.
+ */
+function print_order_summary(array $results): void {
+  Prompty::outro('Order sent to the kitchen!');
+  echo "\nCollected answers:\n";
+  foreach ($results as $key => $value) {
+    $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
+    echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
+  }
+}
+
 $results = Prompty::flow(fn(): array => [
   'course' => Prompty::select('Course',
     options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert'],
@@ -138,14 +153,7 @@ $results = Prompty::flow(fn(): array => [
   ),
 ],
   intro: 'Kitchen order',
-  outro: function (array $results): void {
-    Prompty::outro('Order sent to the kitchen!');
-    echo "\nCollected answers:\n";
-    foreach ($results as $key => $value) {
-      $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
-      echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
-    }
-  },
+  outro: print_order_summary(...),
   cancelled: 'Kitchen order cancelled.',
   numbering: TRUE,
   unicode: $unicode,

--- a/playground/flow.php
+++ b/playground/flow.php
@@ -17,21 +17,6 @@ $opts = getopt('', ['no-unicode', 'no-ansi']);
 $unicode = !isset($opts['no-unicode']);
 $ansi = !isset($opts['no-ansi']);
 
-/**
- * Prints the collected answers once the flow completes.
- *
- * @param array<string, string|bool|int|array<string, string>> $results
- *   Values collected by the flow, keyed by step name.
- */
-function print_order_summary(array $results): void {
-  Prompty::outro('Order sent!');
-  echo "\nCollected answers:\n";
-  foreach ($results as $key => $value) {
-    $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
-    echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
-  }
-}
-
 $results = Prompty::flow(fn(): array => [
   'dish' => Prompty::text('Dish name', placeholder: 'pear tart', description: "Written on the order ticket and under\n\"Specials\" on the board."),
   'course' => Prompty::select('Course',
@@ -57,7 +42,14 @@ $results = Prompty::flow(fn(): array => [
   'send' => Prompty::confirm('Send order?', description: 'Passes the order to the kitchen.'),
 ],
   intro: 'Compose an order',
-  outro: print_order_summary(...),
+  outro: function (array $results): void {
+    Prompty::outro('Order sent!');
+    echo "\nCollected answers:\n";
+    foreach ($results as $key => $value) {
+      $display = is_array($value) ? (count($value) > 0 ? implode(', ', array_filter($value, is_string(...))) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
+      echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
+    }
+  },
   cancelled: 'Order cancelled.',
   numbering: TRUE,
   unicode: $unicode,

--- a/playground/flow.php
+++ b/playground/flow.php
@@ -17,6 +17,21 @@ $opts = getopt('', ['no-unicode', 'no-ansi']);
 $unicode = !isset($opts['no-unicode']);
 $ansi = !isset($opts['no-ansi']);
 
+/**
+ * Prints the collected answers once the flow completes.
+ *
+ * @param array<string, string|bool|int|array<string, string>> $results
+ *   Values collected by the flow, keyed by step name.
+ */
+function print_order_summary(array $results): void {
+  Prompty::outro('Order sent!');
+  echo "\nCollected answers:\n";
+  foreach ($results as $key => $value) {
+    $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
+    echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
+  }
+}
+
 $results = Prompty::flow(fn(): array => [
   'dish' => Prompty::text('Dish name', placeholder: 'pear tart', description: "Written on the order ticket and under\n\"Specials\" on the board."),
   'course' => Prompty::select('Course',
@@ -42,14 +57,7 @@ $results = Prompty::flow(fn(): array => [
   'send' => Prompty::confirm('Send order?', description: 'Passes the order to the kitchen.'),
 ],
   intro: 'Compose an order',
-  outro: function (array $results): void {
-    Prompty::outro('Order sent!');
-    echo "\nCollected answers:\n";
-    foreach ($results as $key => $value) {
-      $display = is_array($value) ? (count($value) > 0 ? implode(', ', $value) : 'none') : (is_bool($value) ? ($value ? 'yes' : 'no') : $value);
-      echo sprintf('  %s: %s%s', $key, $display, PHP_EOL);
-    }
-  },
+  outro: print_order_summary(...),
   cancelled: 'Order cancelled.',
   numbering: TRUE,
   unicode: $unicode,

--- a/playground/widget-multiselect.php
+++ b/playground/widget-multiselect.php
@@ -16,14 +16,16 @@ Prompty::configure(unicode: !isset($opts['no-unicode']), ansi: !isset($opts['no-
 
 echo "\n--- Multiselect: basic ---\n";
 $r = Prompty::multiselect('Extras', options: ['bread' => 'Bread', 'olives' => 'Olives', 'herbs' => 'Herbs']);
-echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+$selection = is_array($r) ? array_filter($r, is_string(...)) : NULL;
+echo '  Result: ' . ($selection === NULL ? 'cancelled' : ($selection === [] ? 'none' : implode(', ', $selection))) . "\n";
 
 echo "\n--- Multiselect: with description ---\n";
 $r = Prompty::multiselect('Drinks',
   options: ['tea' => 'Tea', 'coffee' => 'Coffee', 'juice' => 'Juice'],
   description: "Poured at the table.\nSpace to toggle, enter to confirm.",
 );
-echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+$selection = is_array($r) ? array_filter($r, is_string(...)) : NULL;
+echo '  Result: ' . ($selection === NULL ? 'cancelled' : ($selection === [] ? 'none' : implode(', ', $selection))) . "\n";
 
 echo "\n--- Multiselect: with hints ---\n";
 $r = Prompty::multiselect('Finishes',
@@ -34,7 +36,8 @@ $r = Prompty::multiselect('Finishes',
     'piped' => 'Cream rosettes around the edge.',
   ],
 );
-echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+$selection = is_array($r) ? array_filter($r, is_string(...)) : NULL;
+echo '  Result: ' . ($selection === NULL ? 'cancelled' : ($selection === [] ? 'none' : implode(', ', $selection))) . "\n";
 
 echo "\n--- Multiselect: opt-out (pre-checked default) ---\n";
 $r = Prompty::multiselect('Extras',
@@ -42,4 +45,5 @@ $r = Prompty::multiselect('Extras',
   default: ['bread', 'olives', 'herbs'],
   description: 'All selected; uncheck to remove.',
 );
-echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+$selection = is_array($r) ? array_filter($r, is_string(...)) : NULL;
+echo '  Result: ' . ($selection === NULL ? 'cancelled' : ($selection === [] ? 'none' : implode(', ', $selection))) . "\n";

--- a/playground/widget-select.php
+++ b/playground/widget-select.php
@@ -16,14 +16,14 @@ Prompty::configure(unicode: !isset($opts['no-unicode']), ansi: !isset($opts['no-
 
 echo "\n--- Select: basic ---\n";
 $r = Prompty::select('Course', options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert']);
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Select: with description ---\n";
 $r = Prompty::select('Dish',
   options: ['tart' => 'Pear Tart', 'soup' => 'Onion Soup', 'stew' => 'Lentil Stew', 'omelette' => 'Herb Omelette'],
   description: 'Chosen from the specials board.',
 );
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Select: with hints ---\n";
 $r = Prompty::select('Method',
@@ -34,7 +34,7 @@ $r = Prompty::select('Method',
     'grilled' => "Over the flame for colour.\nFast, hot, and unforgiving.",
   ],
 );
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Select: with default (pre-focused) ---\n";
 $r = Prompty::select('Course',
@@ -42,4 +42,4 @@ $r = Prompty::select('Course',
   default: 'main',
   description: 'Main is focused by default.',
 );
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";

--- a/playground/widget-text.php
+++ b/playground/widget-text.php
@@ -16,16 +16,16 @@ Prompty::configure(unicode: !isset($opts['no-unicode']), ansi: !isset($opts['no-
 
 echo "\n--- Text: basic ---\n";
 $r = Prompty::text('Dish name', placeholder: 'pear tart');
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Text: with description ---\n";
 $r = Prompty::text('Guest name', placeholder: 'Jane Doe', description: "Printed on the order ticket.\nLeave blank for takeaway.");
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Text: no placeholder ---\n";
 $r = Prompty::text('Allergy note');
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Text: with editable default ---\n";
 $r = Prompty::text('Dish name', default: 'pear tart', description: 'Pre-filled and editable.');
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";

--- a/playground/widgets-config.php
+++ b/playground/widgets-config.php
@@ -25,11 +25,11 @@ Prompty::configure(
 
 echo "\n--- Text: with env prefix ---\n";
 $r = Prompty::text('Dish name', placeholder: 'pear tart');
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Select: with custom labels ---\n";
 $r = Prompty::select('Course', options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert']);
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Confirm: with custom labels ---\n";
 $r = Prompty::confirm('Send order?');

--- a/playground/widgets.php
+++ b/playground/widgets.php
@@ -19,7 +19,7 @@ Prompty::configure(unicode: !isset($opts['no-unicode']), ansi: !isset($opts['no-
 
 echo "\n--- Text: with description ---\n";
 $r = Prompty::text('Dish name', placeholder: 'pear tart', description: "Written on the order ticket and under\n\"Specials\" on the board.");
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Select: with hints ---\n";
 $r = Prompty::select('Course',
@@ -31,7 +31,7 @@ $r = Prompty::select('Course',
     'dessert' => 'Sweet, served last.',
   ],
 );
-echo '  Result: ' . ($r ?? 'cancelled') . "\n";
+echo '  Result: ' . (is_string($r) ? $r : 'cancelled') . "\n";
 
 echo "\n--- Multiselect: with hints ---\n";
 $r = Prompty::multiselect('Extras',
@@ -44,7 +44,8 @@ $r = Prompty::multiselect('Extras',
     'lemon' => 'Sharpens rich dishes.',
   ],
 );
-echo '  Result: ' . ($r !== NULL ? (count($r) > 0 ? implode(', ', $r) : 'none') : 'cancelled') . "\n";
+$selection = is_array($r) ? array_filter($r, is_string(...)) : NULL;
+echo '  Result: ' . ($selection === NULL ? 'cancelled' : ($selection === [] ? 'none' : implode(', ', $selection))) . "\n";
 
 echo "\n--- Confirm: with description ---\n";
 $r = Prompty::confirm('Send order?', description: 'Passes the order to the kitchen.');

--- a/rector.php
+++ b/rector.php
@@ -27,9 +27,18 @@ use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
-  ->withPaths([
-    __DIR__ . '/**',
-  ])
+  // Filtered by existence because the embed tests copy this config into a
+  // workspace holding only the file under test, and Rector aborts when a
+  // configured path is missing.
+  ->withPaths(array_filter([
+    __DIR__ . '/Prompty.php',
+    __DIR__ . '/PromptyTestTrait.php',
+    __DIR__ . '/playground',
+    __DIR__ . '/embed.php',
+    __DIR__ . '/starter.php',
+    __DIR__ . '/tests/phpunit',
+    __DIR__ . '/rector.php',
+  ], file_exists(...)))
   ->withPhpSets(php82: TRUE)
   ->withPreparedSets(
     deadCode: TRUE,


### PR DESCRIPTION
Closes #64

## Summary

Issue #64 asked whether the `playground/` demo scripts - the code consumers copy directly - should be held to the same PHPStan bar as the rest of the library. This PR settles it: yes, because the demos are what gets copied, so `playground` is now named explicitly in both `phpstan.neon` and `rector.php`. Adding `playground` to `phpstan.neon`'s `paths` surfaced 28 errors across 8 of the 10 demo files, all now fixed without changing any demo's observable output. `phpcs.xml` already listed `playground`, so it needed no change. `Prompty.php` itself needed no change either - its dual-mode return unions are correct as declared and cannot be narrowed by conditional return types, since the mode depends on mutable static state.

Every fix narrows a value rather than suppressing a diagnostic: no `@phpstan-ignore` comments, no baseline entries, no inline `@var` overrides, no casts, and no widened signatures.

## Changes

- `phpstan.neon`: added `playground` to `paths`.
- `rector.php`: replaced the catch-all `__DIR__ . '/**'` glob with an explicit target list that names `playground`, wrapped in `array_filter(..., file_exists(...))` because the embed functional tests copy this config into a temp workspace containing only the file under test, and Rector aborts when a configured path does not exist. The explicit list is coverage-equivalent to the glob it replaces: PHP's `glob()` never matched dot-entries, so `.util/` and `.github/` were not Rector targets before this change either.
- `playground/widget-text.php`, `playground/widget-select.php`, `playground/widgets-config.php`, `playground/widgets.php`: narrowed `text`/`select` results with `is_string($r) ? $r : 'cancelled'`, replacing `$r ?? 'cancelled'`. The replacement handles cancellation and narrows the union in a single check, so the demo line stays the same length.
- `playground/widget-multiselect.php`, `playground/widgets.php`: narrowed `multiselect` results with `array_filter($r, is_string(...))` before checking for an empty selection and calling `implode()`.
- `playground/flow-multiple.php`: narrowed flow-result values (`dish`, `course`, the kitchen note, `extras`) before concatenation and `implode()`.
- `playground/flow.php`, `playground/flow-nested.php`: kept the `outro:` callbacks inline - demonstrating a callback defined right at the call site is the point of those demos - and narrowed `$value` inside the loop instead, so each file changes by a single expression. Typing the callback parameter via a docblock was not an option: PHPStan does not read a `@param` docblock attached to a closure passed as a named argument, nor one attached to a closure assigned to a variable.
- `playground/widget-confirm.php` and `playground/flow-config.php` needed no change - the `!== NULL ? ... : ...` idiom already yields a string on both branches, and `flow-config.php` iterates `flow()`'s declared return type rather than an untyped callback parameter.

Output stability was verified empirically rather than argued: all 10 demos were driven to completion with an identical keystroke stream and their output compared byte-for-byte against `main`. All 10 matched, so the recorded SVG assets remain valid. Rector's reach into `playground/` was confirmed the same way, by planting a rule violation there and checking that `composer lint` flagged it.

As a non-blocking follow-up: the README's callable-outro snippet still uses an inline closure and would hit the same PHPStan error if a consumer copied it as-is. It was left unchanged because it illustrates the API shape rather than being a demo file, which is outside this issue's scope.

## Before / After

```
┌─ BEFORE ──────────────────────────────────────────────────────┐
│ Which tools target playground/                                │
│   PHPCS    yes  (<file>playground</file>)                     │
│   Rector   incidentally, via a __DIR__ . '/**' catch-all      │
│   PHPStan  NO   -> 28 latent errors, never reported           │
│                                                               │
│ playground/widget-select.php                                  │
│   echo '  Result: ' . ($r ?? 'cancelled');                    │
│   -> Closure|array still in the union at the concatenation    │
│                                                               │
│ playground/flow.php - outro callback                          │
│   outro: function (array $results): void {                    │
│     ... implode(', ', $value)                                 │
│   -> $value is mixed; implode wants array<string>             │
└───────────────────────────────────────────────────────────────┘

┌─ AFTER ───────────────────────────────────────────────────────┐
│ Which tools target playground/                                │
│   PHPCS    yes  (unchanged)                                   │
│   Rector   yes, named explicitly in the path list             │
│   PHPStan  yes  -> 34 files scanned, 0 errors                 │
│                                                               │
│ playground/widget-select.php                                  │
│   echo '  Result: ' . (is_string($r) ? $r : 'cancelled');     │
│   -> narrowed to string before concatenation                  │
│                                                               │
│ playground/flow.php - outro callback STILL INLINE             │
│   outro: function (array $results): void {                    │
│     ... implode(', ', array_filter($value, is_string(...)))   │
│   -> narrowed in place; callback stays at the call site       │
└───────────────────────────────────────────────────────────────┘
```
