### PR TITLE
Fixed README API drift, added 'CONTRIBUTING.md' and 'SECURITY.md', and tidied source comments.

### DIFF
--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -910,8 +910,8 @@ EXPECT;
  *
  * Both pipes are polled together rather than read one after the other, so a
  * worker that fills one pipe buffer cannot block while this waits on the
- * other. Returns only once the worker has closed both ends, which is what
- * makes the captured output complete enough to diagnose a failure.
+ * other. Returns only once the worker has closed both ends, so the captured
+ * output is complete enough to diagnose a failure.
  *
  * @param resource $stdout_pipe
  *   The worker's stdout pipe.

--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -910,8 +910,9 @@ EXPECT;
  *
  * Both pipes are polled together rather than read one after the other, so a
  * worker that fills one pipe buffer cannot block while this waits on the
- * other. Returns only once the worker has closed both ends, so the captured
- * output is complete enough to diagnose a failure.
+ * other. Returns once the worker has closed both ends, so the captured output
+ * is complete enough to diagnose a failure. A stream_select() failure ends the
+ * loop early and returns whatever was read up to that point.
  *
  * @param resource $stdout_pipe
  *   The worker's stdout pipe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ Namespace: `AlexSkrypnyk\Prompty`. Key files: `Prompty.php` (library),
 
 ### Playground
 
-- `playground/widgets.php` - standalone widget demos.
-- `playground/flow.php` - linear flow.
-- `playground/flow-nested.php` - nested flow with conditionals.
+`playground/` holds runnable demos - `widgets*.php` and `widget-*.php` for
+standalone widgets, `flow*.php` for flows. `CONTRIBUTING.md` lists what each
+one shows and which accept `--no-unicode` / `--no-ansi`.
 
 ## Demo content
 
@@ -52,14 +52,14 @@ composer lint          # PHPCS + PHPStan + Rector dry-run
 composer lint-fix      # Rector + PHPCBF
 composer test          # PHPUnit (no coverage)
 composer test-coverage # PHPUnit with coverage
-composer reset         # rm vendor/, reinstall
+composer reset         # rm vendor/, vendor-bin/, composer.lock
 ```
 
 ## Code Quality
 
 1. **PHPCS** - Drupal standard + strict types (`phpcs.xml`)
 2. **PHPStan** - Level 9 (`phpstan.neon`)
-3. **Rector** - PHP 8.2/8.3 modernization (`rector.php`)
+3. **Rector** - PHP 8.2 modernization (`rector.php`)
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ The library itself is deliberately a single class in a single file with no depen
 
 ## Tests
 
-```
+```text
 tests/phpunit/Unit/Prompty/   Unit tests, driven through PromptyTestTrait.
 tests/phpunit/Functional/     Runs embed.php and starter.php as subprocesses.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing
+
+Thanks for taking an interest. Bug reports, fixes and ideas are all welcome - open an [issue](https://github.com/AlexSkrypnyk/prompty/issues) or a pull request.
+
+## Requirements
+
+PHP 8.2 or newer, and Composer. CI runs the suite on PHP 8.2, 8.3, 8.4 and 8.5, against both current and lowest resolvable dependencies, so a change that only works on the newest PHP won't get through.
+
+`composer.lock` isn't committed, so a fresh clone resolves dependencies from scratch.
+
+## Setup
+
+```bash
+git clone https://github.com/AlexSkrypnyk/prompty.git
+cd prompty
+composer install
+```
+
+## Commands
+
+| Command                  | What it does                                          |
+|--------------------------|-------------------------------------------------------|
+| `composer lint`          | PHPCS, then PHPStan, then Rector in dry-run mode.      |
+| `composer lint-fix`      | Rector, then PHPCBF. Fixes what can be fixed.          |
+| `composer test`          | PHPUnit without coverage.                              |
+| `composer test-coverage` | PHPUnit with coverage, written to `.logs/`.            |
+| `composer reset`         | Removes `vendor/`, `vendor-bin/` and `composer.lock`.  |
+
+`composer reset` only deletes - run `composer install` afterwards to get back to a working tree.
+
+## Code quality
+
+Three tools gate every change, and CI runs all of them:
+
+- **PHPCS** - the Drupal standard plus DrevOps rules, with `strict_types` required in every file. Config in [`phpcs.xml`](phpcs.xml).
+- **PHPStan** - level 9, the strictest level. Config in [`phpstan.neon`](phpstan.neon).
+- **Rector** - PHP 8.2 modernisation plus dead-code, code-quality, coding-style, type-declaration, naming and early-return sets, run in dry-run mode during linting. Config in [`rector.php`](rector.php).
+
+Coverage has a threshold in CI (80% by default, set via the `CI_CODE_COVERAGE_THRESHOLD` repository variable). New code needs tests.
+
+## Conventions
+
+- `declare(strict_types=1)` at the top of every PHP file.
+- Single quotes for strings, unless the string contains one.
+- `snake_case` for local variables and method arguments; `camelCase` for method names and class properties.
+- Every file ends with a newline.
+
+The library itself is deliberately a single class in a single file with no dependencies. Anything that would introduce a `require` of something outside `Prompty.php` needs a good reason.
+
+## Tests
+
+```
+tests/phpunit/Unit/Prompty/   Unit tests, driven through PromptyTestTrait.
+tests/phpunit/Functional/     Runs embed.php and starter.php as subprocesses.
+```
+
+Unit tests extend `PromptyTestCase` and use `PromptyTestTrait` to feed keystrokes into a memory stream, so no real TTY is needed. Functional tests shell out, which makes them slower but catches things the unit tests can't - like whether an embedded script still parses.
+
+Use data providers where you can. Name the provider `dataProvider<Something>` and put it *after* the test method it feeds.
+
+Arguments after `--` reach PHPUnit, so a single file or a filter looks like:
+
+```bash
+composer test -- tests/phpunit/Unit/Prompty/PromptyRenderTest.php
+composer test -- --filter testRenderIntro
+```
+
+## Playground
+
+The [`playground/`](playground) directory holds runnable demos - the quickest way to see a change in a real terminal:
+
+| Script                        | Shows                                              |
+|-------------------------------|----------------------------------------------------|
+| `widgets.php`                 | Each widget type standalone, one after another.     |
+| `widget-text.php`             | Text widget variants.                               |
+| `widget-select.php`           | Select widget variants.                             |
+| `widget-multiselect.php`      | Multiselect widget variants.                        |
+| `widget-confirm.php`          | Confirm widget variants.                            |
+| `widgets-config.php`          | Standalone widgets with custom configuration.       |
+| `flow.php`                    | A linear flow with descriptions and hints.          |
+| `flow-nested.php`             | A nested flow with conditionals, 3 levels deep.     |
+| `flow-config.php`             | A flow with `configure()` applied beforehand.       |
+| `flow-multiple.php`           | Several flows, and a standalone widget between them.|
+
+```bash
+php playground/flow-nested.php
+```
+
+Most of them accept `--no-unicode` and `--no-ansi` to force a display mode:
+
+```bash
+php playground/flow.php --no-unicode --no-ansi
+```
+
+`flow-config.php` and `flow-multiple.php` set their display mode in code instead, so the flags do nothing there.
+
+## Demo content
+
+Every example in the repository - playground scripts, `starter.php`, README snippets and recorded assets - uses one kitchen-order theme, with no software or technology references. The vocabulary is defined in [`.claude/demo_content_reference.md`](.claude/demo_content_reference.md).
+
+Take labels, keys and hints from that file rather than inventing them. If a demo needs a concept the file doesn't cover, add it there first.
+
+## Regenerating the README assets
+
+The SVGs under `.util/assets/` are recorded from the playground scripts. Regenerate them after any change to rendering:
+
+```bash
+php .util/update-assets.php
+```
+
+That records all 7 scripts in 4 flag variants each, in parallel. To redo just one:
+
+```bash
+php .util/update-assets.php --record widgets
+```
+
+It needs `asciinema`, `expect`, `node` and `npm` on your PATH. Set `SCRIPT_QUIET=1` to suppress progress output.
+
+## Releases
+
+Publishing a GitHub release triggers [`release.yml`](.github/workflows/release.yml), which:
+
+1. Substitutes the tag name for the `__PROMPTY_VERSION__` token in `Prompty.php`, so `Prompty::version()` reports the release instead of `development`.
+2. Runs `starter.php` once as a smoke test.
+3. Builds `Prompty.min.php` and `Prompty.compact.php` with `embed.php --stdout`.
+4. Generates `SHA256SUMS` over every asset and signs it with the maintainer's GPG key.
+5. Verifies the signature and checksums, uploads everything, then downloads it all again and re-verifies.
+
+Release notes are drafted automatically by [`draft-release-notes.yml`](.github/workflows/draft-release-notes.yml) using the categories in [`.github/release-drafter.yml`](.github/release-drafter.yml).

--- a/Prompty.php
+++ b/Prompty.php
@@ -216,6 +216,7 @@ class Prompty {
       // @phpstan-ignore new.static
       static::$instance = new static();
     }
+
     return static::$instance;
   }
 
@@ -227,6 +228,7 @@ class Prompty {
    */
   public static function config(): array {
     $p = static::instance();
+
     return [
       'symbols_unicode' => $p->cfgSymbolsUnicode,
       'symbols_ascii' => $p->cfgSymbolsAscii,
@@ -257,7 +259,7 @@ class Prompty {
    *
    * Returns 'development' when the version token has not been replaced
    * (i.e. running from source). During release, the __PROMPTY_VERSION__
-   * token is replaced with the actual tag via sed.
+   * token is replaced with the actual tag.
    *
    * @return string
    *   The version string.
@@ -509,6 +511,7 @@ class Prompty {
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
+
       return $call;
     }
 
@@ -541,6 +544,7 @@ class Prompty {
         $p->teardownTty();
         // @codeCoverageIgnoreEnd
       }
+
       return $display;
     }
 
@@ -580,6 +584,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return NULL;
       }
 
@@ -591,6 +596,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return $display;
       }
 
@@ -662,6 +668,7 @@ class Prompty {
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
+
       return $call;
     }
 
@@ -699,6 +706,7 @@ class Prompty {
         $p->teardownTty();
         // @codeCoverageIgnoreEnd
       }
+
       return $resolved_str;
     }
 
@@ -765,6 +773,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return NULL;
       }
 
@@ -775,6 +784,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return $option_keys[$focused];
       }
 
@@ -838,6 +848,7 @@ class Prompty {
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
+
       return $call;
     }
 
@@ -879,6 +890,7 @@ class Prompty {
         $p->teardownTty();
         // @codeCoverageIgnoreEnd
       }
+
       return $resolved_array;
     }
 
@@ -942,6 +954,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return NULL;
       }
 
@@ -962,6 +975,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return $selected_keys;
       }
 
@@ -1020,6 +1034,7 @@ class Prompty {
       if ($condition !== NULL || $children !== []) {
         return ['__call' => $call, '__children' => $children, '__condition' => $condition];
       }
+
       return $call;
     }
 
@@ -1065,6 +1080,7 @@ class Prompty {
         $p->teardownTty();
         // @codeCoverageIgnoreEnd
       }
+
       return (bool) $discovered;
     }
 
@@ -1107,6 +1123,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return NULL;
       }
 
@@ -1117,6 +1134,7 @@ class Prompty {
           $p->teardownTty();
           // @codeCoverageIgnoreEnd
         }
+
         return $yes;
       }
 
@@ -1298,6 +1316,7 @@ class Prompty {
     if ($prev_line_count > 0) {
       echo "\033[{$prev_line_count}A\r\033[J";
     }
+
     return $this->printLines($lines);
   }
 
@@ -1360,6 +1379,7 @@ class Prompty {
       $number = $ctx['number'];
       return $label . ' ' . $this->color('(' . $number . ')', 'dim');
     }
+
     return $label;
   }
 

--- a/PromptyTestTrait.php
+++ b/PromptyTestTrait.php
@@ -139,8 +139,6 @@ trait PromptyTestTrait {
       }
     }
 
-    // Pre-create a singleton with the stream injected.
-    // The script's flow() call reuses this instance.
     $instance = $this->promptyCreateInstance();
     if ($stream !== NULL) {
       $this->promptySetProperty($instance, 'input', $stream);

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ See [Usage](#usage) for how to embed the class directly into your script.
 
 ### Verifying a download
 
-Every release ships a `SHA256SUMS` file covering all assets, signed with the maintainer's GPG key as `SHA256SUMS.asc`. The matching public key is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository.
+Every release ships a `SHA256SUMS` file covering all assets, signed with the maintainer's GPG key as `SHA256SUMS.asc`. The matching public key is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository, with this fingerprint:
+
+```text
+755E 824E 80F8 4913 5F5F  4043 E71E DB25 C4F6 D89D
+```
 
 ```bash
 BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
@@ -72,12 +76,15 @@ curl -LO $BASE/SHA256SUMS
 curl -LO $BASE/SHA256SUMS.asc
 curl -LO $RAW/PUBLIC_KEY.asc
 
+# Check the fingerprint against the one above before trusting the key.
+gpg --show-keys --with-fingerprint PUBLIC_KEY.asc
+
 gpg --import PUBLIC_KEY.asc
 gpg --verify SHA256SUMS.asc SHA256SUMS
 sha256sum --ignore-missing -c SHA256SUMS
 ```
 
-`--ignore-missing` lets the checksum check pass when only some assets were downloaded.
+`--ignore-missing` lets the checksum check pass when only some assets were downloaded. See [`SECURITY.md`](SECURITY.md) for what this verification does and does not prove.
 
 ### Composer
 
@@ -543,7 +550,8 @@ $results = Prompty::flow(fn(): array => [/* ... */]);
 // Or read them later.
 $results = Prompty::results();
 
-// Print your own banner from inside an outro callable.
+// Print a banner yourself. Passing a callable as flow()'s outro suppresses
+// the built-in one, so call this from inside it to keep the banner.
 Prompty::outro('Order sent to the kitchen!');
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="" rel="noopener">
+  <a href="https://github.com/AlexSkrypnyk/prompty" rel="noopener">
   <img height=200px src="logo.png" alt="Prompty logo"></a>
 </p>
 
@@ -41,13 +41,11 @@
 
 ## Installation
 
-Prompty is a single PHP file with zero dependencies.
+Prompty is a single PHP file with zero dependencies. It requires PHP 8.2 or newer.
 
 ### Download from releases
 
-Download `Prompty.php` from the
-[latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest)
-assets.
+Download `Prompty.php` from the [latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest) assets.
 
 Three variants are available:
 
@@ -60,6 +58,26 @@ Three variants are available:
 For testing, also download `PromptyTestTrait.php` from the same release.
 
 See [Usage](#usage) for how to embed the class directly into your script.
+
+### Verifying a download
+
+Every release ships a `SHA256SUMS` file covering all assets, signed with the maintainer's GPG key as `SHA256SUMS.asc`. The matching public key is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository.
+
+```bash
+BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
+RAW=https://raw.githubusercontent.com/AlexSkrypnyk/prompty/main
+
+curl -LO $BASE/Prompty.php
+curl -LO $BASE/SHA256SUMS
+curl -LO $BASE/SHA256SUMS.asc
+curl -LO $RAW/PUBLIC_KEY.asc
+
+gpg --import PUBLIC_KEY.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+`--ignore-missing` lets the checksum check pass when only some assets were downloaded.
 
 ### Composer
 
@@ -81,15 +99,13 @@ use AlexSkrypnyk\Prompty\Prompty;
 $dish = Prompty::text('Dish name');
 ```
 
-Or [embed](#embedding) the minified class directly into your script (using
-provided minification script) to ship a single file with no external dependencies.
+Or [embed](#embedding) the minified class directly into your script (using the provided minification script) to ship a single file with no external dependencies.
 
 You may also use the [starter](#starter-script) as a template for your own scripts.
 
 ## Widgets
 
-Four widget types cover the most common prompt patterns. Each returns the user's
-answer, or `null` if they cancel (Escape or Ctrl+C).
+Four widget types cover the most common prompt patterns. Each returns the user's answer, or `null` if they cancel (Escape or Ctrl+C).
 
 ### Text
 
@@ -99,12 +115,14 @@ Free-form text input with an optional editable `default` and placeholder.
 $dish = Prompty::text('Dish name',
   default: 'pear tart',
   placeholder: 'e.g. pear tart',
-  description: "Written on the order ticket and under\n\"Specials\" on the board.",
+  description: "Written on the order ticket and under\n"
+    . '"Specials" on the board.',
 );
 ```
 
-`default` pre-fills the input with an editable value; `placeholder` is the gray
-hint shown only while the input is empty.
+`default` pre-fills the input with an editable value; `placeholder` is the gray hint shown only while the input is empty.
+
+Submitting an empty input returns the `placeholder` string as the answer, so a placeholder doubles as a non-editable fallback value. Leave `placeholder` unset if an empty answer should stay empty.
 
 <table>
   <tr>
@@ -126,12 +144,15 @@ hint shown only while the input is empty.
 
 ### Select
 
-Single-choice from a list. Arrow keys to navigate, Enter to confirm. Pass
-`default` (an option key) to focus an option other than the first.
+Single-choice from a list. Arrow keys to navigate, Enter to confirm. Pass `default` (an option key) to focus an option other than the first.
 
 ```php
 $course = Prompty::select('Course',
-  options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert'],
+  options: [
+    'starter' => 'Starter',
+    'main' => 'Main',
+    'dessert' => 'Dessert',
+  ],
   default: 'main',
   description: 'Where the dish sits in the meal.',
   hints: [
@@ -162,15 +183,18 @@ $course = Prompty::select('Course',
 
 ### Multiselect
 
-Multiple-choice from a list. Space to toggle, Enter to confirm. Pass `default`
-(a list of option keys) to pre-check options - ideal for opt-out lists where
-every option starts selected and the user unchecks what they don't want.
+Multiple-choice from a list. Space to toggle, Enter to confirm. Pass `default` (a list of option keys) to pre-check options - ideal for opt-out lists where every option starts selected and the user unchecks what they don't want.
 
 ```php
 $extras = Prompty::multiselect('Extras',
-  options: ['bread' => 'Bread', 'olives' => 'Olives', 'herbs' => 'Herbs'],
+  options: [
+    'bread' => 'Bread',
+    'olives' => 'Olives',
+    'herbs' => 'Herbs',
+  ],
   default: ['bread', 'olives', 'herbs'],
-  description: "Anything served alongside.\nSpace to toggle, enter to confirm.",
+  description: "Anything served alongside.\n"
+    . 'Space to toggle, enter to confirm.',
 );
 ```
 
@@ -241,6 +265,8 @@ $results = Prompty::flow(fn(): array => [
 ], intro: 'Compose an order', outro: 'Order sent!');
 ```
 
+`flow()` returns the collected answers keyed by step name, or `null` if the user cancels any step.
+
 Flows support intro, outro, and cancellation messages — as strings or callables:
 
 ```php
@@ -256,9 +282,7 @@ $results = Prompty::flow(fn(): array => [ /* ... */ ],
 
 ### Nested flows with conditions
 
-Widgets accept `children` and `condition` to build tree-structured flows.
-Children render as an indented tree with bar connectors. Conditions receive
-the collected results so far and skip the step when they return `false`.
+Widgets accept `children` and `condition` to build tree-structured flows. Children render as an indented tree with bar connectors. Conditions receive the collected results so far and skip the step when they return `false`.
 
 ```php
 $results = Prompty::flow(fn(): array => [
@@ -266,11 +290,19 @@ $results = Prompty::flow(fn(): array => [
     options: ['main' => 'Main', 'dessert' => 'Dessert'],
     children: [
       'method' => Prompty::select('Method',
-        options: ['baked' => 'Baked', 'poached' => 'Poached', 'grilled' => 'Grilled'],
+        options: [
+          'baked' => 'Baked',
+          'poached' => 'Poached',
+          'grilled' => 'Grilled',
+        ],
         condition: fn($r): bool => ($r['course'] ?? '') === 'main',
       ),
       'finishes' => Prompty::multiselect('Finishes',
-        options: ['glazed' => 'Glazed', 'dusted' => 'Dusted', 'piped' => 'Piped'],
+        options: [
+          'glazed' => 'Glazed',
+          'dusted' => 'Dusted',
+          'piped' => 'Piped',
+        ],
         condition: fn($r): bool => ($r['course'] ?? '') === 'dessert',
       ),
     ],
@@ -280,14 +312,18 @@ $results = Prompty::flow(fn(): array => [
 
 ## Standalone mode
 
-Widgets work outside of flows too. Call any widget directly and it handles
-TTY setup/teardown internally, returning the answer immediately:
+Widgets work outside of flows too. Call any widget directly and it handles TTY setup/teardown internally, returning the answer immediately:
 
 ```php
 require_once 'Prompty.php';
 
+use AlexSkrypnyk\Prompty\Prompty;
+
 $dish = Prompty::text('Dish name');
-$course = Prompty::select('Course', options: ['starter' => 'Starter', 'main' => 'Main']);
+$course = Prompty::select('Course', options: [
+  'starter' => 'Starter',
+  'main' => 'Main',
+]);
 $send = Prompty::confirm('Send order?');
 
 echo "Sending $dish for the $course course...\n";
@@ -296,32 +332,32 @@ echo "Sending $dish for the $course course...\n";
 You can mix standalone widgets with flows in the same script:
 
 ```php
+// Standalone widgets can sit between flows.
 $dish = Prompty::flow(fn(): array => [/* step 1 */], intro: 'Step 1: The dish');
-$note = Prompty::text('Kitchen note'); // standalone between flows
+$note = Prompty::text('Kitchen note');
 $extras = Prompty::flow(fn(): array => [/* step 2 */], intro: 'Step 2: Extras');
 ```
 
 ## Environment variable discovery
 
-Flows auto-discover answers from environment variables. The key name is
-uppercased and prefixed with `PROMPTY_` (configurable):
+Flows auto-discover answers from environment variables. The key name is uppercased and prefixed with `PROMPTY_` (configurable):
 
 ```bash
 PROMPTY_DISH='pear tart' PROMPTY_COURSE=main php your-script.php
 ```
 
-This pre-fills `dish` and `course` without prompting the user. The flow
-renders the discovered values as completed steps and moves on.
+This pre-fills `dish` and `course` without prompting the user. The flow renders the discovered values as completed steps and moves on.
 
 Configure the prefix per-flow or globally:
 
 ```php
-$results = Prompty::flow(fn(): array => [/* ... */], env_prefix: 'KITCHEN_');
 // Reads KITCHEN_DISH, KITCHEN_COURSE, etc.
+$results = Prompty::flow(fn(): array => [/* ... */], env_prefix: 'KITCHEN_');
 ```
 
-For confirm widgets, env values are interpreted using configurable truthy/falsy
-lists (default: `1`/`true`/`yes` and `0`/`false`/`no`).
+Multiselect values are read as a comma-separated list, so `PROMPTY_EXTRAS=bread,olives` selects both options.
+
+For confirm widgets, env values are interpreted using configurable truthy/falsy lists (default: `1`/`true`/`yes` and `0`/`false`/`no`).
 
 ## Descriptions and hints
 
@@ -329,31 +365,34 @@ Every widget accepts a `description` — multi-line text rendered below the labe
 
 ```php
 Prompty::text('Dish name',
-  description: "Written on the order ticket and under\n\"Specials\" on the board.",
+  description: "Written on the order ticket and under\n"
+    . '"Specials" on the board.',
 );
 ```
 
-Select and multiselect widgets also accept `hints` — per-option text that
-updates as the user navigates:
+Select and multiselect widgets also accept `hints` — per-option text that updates as the user navigates:
 
 ```php
 Prompty::select('Method',
-  options: ['baked' => 'Baked', 'poached' => 'Poached', 'grilled' => 'Grilled'],
+  options: [
+    'baked' => 'Baked',
+    'poached' => 'Poached',
+    'grilled' => 'Grilled',
+  ],
   hints: [
     'baked' => 'Dry heat, all the way through.',
-    'poached' => "Gently, in barely moving liquid.\nKeeps delicate things whole.",
+    'poached' => "Gently, in barely moving liquid.\n"
+      . 'Keeps delicate things whole.',
     'grilled' => 'Over the flame for colour. Fast, hot, and unforgiving.',
   ],
 );
 ```
 
-Hints support multi-line text. They appear below the option list and change
-as the user moves between options.
+Hints support multi-line text. They appear below the option list and change as the user moves between options.
 
 ## Default values
 
-Every interactive widget can seed its starting state with `default`, so the user
-begins from a sensible answer and adjusts from there:
+Every interactive widget can seed its starting state with `default`, so the user begins from a sensible answer and adjusts from there:
 
 | Widget        | `default` type        | Effect                                     |
 |---------------|-----------------------|--------------------------------------------|
@@ -371,15 +410,11 @@ $extras = Prompty::multiselect('Extras', options: [
 ], default: ['bread', 'olives', 'herbs']);
 ```
 
-`default` only seeds the *interactive* starting state. A value supplied via
-`discovered` or a `PROMPTY_*` environment variable still takes precedence and
-skips the prompt entirely, so explicit input always wins over the default.
+`default` only seeds the *interactive* starting state. A value supplied via `discovered` or a `PROMPTY_*` environment variable still takes precedence and skips the prompt entirely, so explicit input always wins over the default.
 
 ## Unicode and ASCII
 
-Prompty auto-detects Unicode support from the terminal locale (`LANG`,
-`LC_ALL`, `LC_CTYPE`). When Unicode is available, it uses symbols like `◆`,
-`◇`, `│`, `●`. Otherwise, it falls back to ASCII: `+`, `o`, `|`, `(*)`.
+Prompty auto-detects Unicode support from the terminal locale (`LANG`, `LC_ALL`, `LC_CTYPE`). When Unicode is available, it uses symbols like `◆`, `◇`, `│`, `●`. Otherwise, it falls back to ASCII: `+`, `o`, `|`, `(*)`.
 
 Force a mode:
 
@@ -396,8 +431,7 @@ $results = Prompty::flow(fn(): array => [/* ... */], unicode: FALSE);
 
 ## ANSI colors
 
-Prompty auto-detects ANSI color support. It respects the
-[`NO_COLOR`](https://no-color.org/) environment variable and `TERM=dumb`.
+Prompty auto-detects ANSI color support. It respects the [`NO_COLOR`](https://no-color.org/) environment variable and `TERM=dumb`.
 
 Force colors on or off:
 
@@ -414,8 +448,7 @@ $results = Prompty::flow(fn(): array => [/* ... */], ansi: FALSE);
 
 ### Display modes
 
-Combine `unicode` and `ansi` to control the output style. Here is how a flat
-flow looks in each combination:
+Combine `unicode` and `ansi` to control the output style. Here is how a flat flow looks in each combination:
 
 <table align="center">
   <tr>
@@ -457,9 +490,7 @@ And a nested flow:
 
 ## Configuration
 
-Configure globally with `Prompty::configure()` or per-flow via named arguments
-on `Prompty::flow()`. All parameters are optional — pass only what you want to
-override. Per-flow config merges on top of global.
+Configure globally with `Prompty::configure()` or per-flow via named arguments on `Prompty::flow()`. All parameters are optional — pass only what you want to override. Per-flow config merges on top of global.
 
 ```php
 // Global.
@@ -492,7 +523,18 @@ $results = Prompty::flow(fn(): array => [/* ... */],
 | `colors`          | `array<string, string>` | ANSI color escape overrides                              |
 | `spacing`         | `array<string, string>` | Indentation strings                                      |
 
-### Reading results
+### Other methods
+
+Besides the four widgets and `flow()`, the class exposes:
+
+| Method                    | Returns  | Description                                                     |
+|---------------------------|----------|-----------------------------------------------------------------|
+| `Prompty::results()`      | `array`  | The answers collected by the last flow.                         |
+| `Prompty::config()`       | `array`  | The resolved configuration, including auto-detected values.     |
+| `Prompty::version()`      | `string` | The release version, or `development` when running from source. |
+| `Prompty::intro($text)`   | `void`   | Prints an intro banner outside of `flow()`.                     |
+| `Prompty::outro($text)`   | `void`   | Prints an outro banner outside of `flow()`.                     |
+| `Prompty::output($lines)` | `int`    | Prints an array of lines in Prompty's style; returns the count. |
 
 ```php
 // flow() returns the collected answers.
@@ -501,22 +543,25 @@ $results = Prompty::flow(fn(): array => [/* ... */]);
 // Or read them later.
 $results = Prompty::results();
 
-// Read the full config.
-$config = Prompty::config();
+// Print your own banner from inside an outro callable.
+Prompty::outro('Order sent to the kitchen!');
 ```
 
 ## Test harness
 
-Prompty ships with `PromptyTestTrait` for PHPUnit. It injects keystrokes into
-a memory stream and captures terminal output — no real TTY needed.
+Prompty ships with `PromptyTestTrait` for PHPUnit. It injects keystrokes into a memory stream and captures terminal output — no real TTY needed.
+
+Use `promptyRun()` when the flow's return value is what you want to assert on:
 
 ```php
+use AlexSkrypnyk\Prompty\Prompty;
+use AlexSkrypnyk\Prompty\PromptyTestTrait;
 use PHPUnit\Framework\TestCase;
 
 require_once 'Prompty.php';
 require_once 'PromptyTestTrait.php';
 
-class MyTest extends TestCase {
+class MyFlowTest extends TestCase {
   use PromptyTestTrait;
 
   protected function tearDown(): void {
@@ -528,20 +573,43 @@ class MyTest extends TestCase {
     $keystrokes = $this->promptyKeys(
       'plum compote', self::KEY_ENTER,  // type dish + submit
       self::KEY_DOWN, self::KEY_ENTER,  // select second option
-      self::KEY_SPACE, self::KEY_ENTER, // toggle first + submit
-      self::KEY_ENTER,                  // confirm default
     );
 
-    $this->promptyRunScript(function (): void {
-      require 'my-script.php';
-    }, $keystrokes);
+    $run = $this->promptyRun(fn(): mixed => Prompty::flow(fn(): array => [
+      'dish' => Prompty::text('Dish name'),
+      'course' => Prompty::select('Course', options: [
+        'starter' => 'Starter',
+        'main' => 'Main',
+      ]),
+    ]), $keystrokes);
 
-    $results = \Prompty::results();
-    $this->assertSame('plum compote', $results['dish']);
-    $this->assertSame('main', $results['course']);
+    $this->assertSame('plum compote', $run['result']['dish']);
+    $this->assertSame('main', $run['result']['course']);
+    $this->assertStringContainsString('Dish name', $run['output']);
   }
 }
 ```
+
+Use `promptyRunScript()` to drive a consumer script instead. Leave the script's [kill switch](#starter-script) variable unset so it stops before doing real work, then read the answers from `Prompty::results()`:
+
+```php
+public function testMyScript(): void {
+  $keystrokes = $this->promptyKeys(
+    'plum compote', self::KEY_ENTER,
+    self::KEY_DOWN, self::KEY_ENTER,
+  );
+
+  $this->promptyRunScript(function (): void {
+    require 'my-script.php';
+  }, $keystrokes);
+
+  $results = Prompty::results();
+  $this->assertSame('plum compote', $results['dish']);
+  $this->assertSame('main', $results['course']);
+}
+```
+
+Both helpers return an array with an ANSI-stripped `output` key; `promptyRun()` adds a `result` key holding the callback's return value.
 
 ### Available key constants
 
@@ -560,9 +628,7 @@ class MyTest extends TestCase {
 
 ## Starter script
 
-[`starter.php`](starter.php) is a ready-to-use template for your own scripts.
-It demonstrates the recommended "kill switch" pattern for testable flows — the
-script collects answers, then checks an env var before doing real work:
+[`starter.php`](starter.php) is a ready-to-use template for your own scripts. It demonstrates the recommended "kill switch" pattern for testable flows — the script collects answers, then checks an env var before doing real work:
 
 ```php
 $results = Prompty::flow(fn(): array => [
@@ -582,18 +648,13 @@ Copy `starter.php`, rename it, and replace the steps with your own.
 
 ## Embedding
 
-[`embed.php`](embed.php) minifies `Prompty.php` (strips comments, collapses
-blank lines) and embeds it directly into your script — so you can ship a single
-file with no `require_once` and no external dependencies.
+[`embed.php`](embed.php) minifies `Prompty.php` (strips comments, collapses blank lines) and embeds it directly into your script — so you can ship a single file with no `require_once` and no external dependencies.
 
-Download `embed.php` from the
-[latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest)
-assets alongside `Prompty.php`.
+Download `embed.php` from the [latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest) assets alongside `Prompty.php`.
 
 ### Setup
 
-Add `// @embed-start` and `// @embed-end` markers in your script around the
-`require_once` line:
+Add `// @embed-start` and `// @embed-end` markers in your script around the `require_once` line:
 
 ```php
 <?php
@@ -625,31 +686,30 @@ Embed into a separate output file (source stays unchanged):
 php embed.php my-script.php dist/my-script.php
 ```
 
-Use `--compact` to collapse the entire class into a single line (plus the
-license header comment):
-
-```bash
-php embed.php --compact my-script.php
-```
-
-Use `--source` to specify an alternative path to the class file to embed
-(defaults to `Prompty.php` in the same directory as `embed.php`):
-
-```bash
-php embed.php --source /path/to/Prompty.php my-script.php
-```
-
-Wrap the markers in `// phpcs:disable` / `// phpcs:enable`
-to suppress coding standard warnings on the minified code.
+Wrap the markers in `// phpcs:disable` / `// phpcs:enable` to suppress coding standard warnings on the minified code.
 
 See [`starter.php`](starter.php) for an example with markers already in place.
 
+### Options
+
+| Option            | Description                                                                              |
+|-------------------|------------------------------------------------------------------------------------------|
+| `--source <path>` | Path to the class file to embed. Defaults to `Prompty.php` beside `embed.php`.            |
+| `--compact`       | Collapse the class onto a single line and shorten internal names, for a smaller output.   |
+| `--stdout`        | Write the processed class as a standalone PHP file instead of embedding into a script.    |
+| `--no-killswitch` | Skip injecting the kill switch block and the post-embed verification run.                 |
+
+```bash
+php embed.php --compact my-script.php
+php embed.php --source /path/to/Prompty.php my-script.php
+php embed.php --stdout Prompty.min.php
+```
+
+`--stdout` takes an output path rather than a target script, and is how the release workflow builds the `Prompty.min.php` and `Prompty.compact.php` assets.
+
 ### Re-embedding
 
-To update an already-embedded script to a newer version of Prompty, replace
-`Prompty.php` with the new version and re-run `embed.php`. The embedded region
-is replaced with the latest class content while all code outside the markers is
-preserved:
+To update an already-embedded script to a newer version of Prompty, replace `Prompty.php` with the new version and re-run `embed.php`. The embedded region is replaced with the latest class content while all code outside the markers is preserved:
 
 ```bash
 php embed.php my-script.php
@@ -663,9 +723,7 @@ php embed.php --source /path/to/new/Prompty.php my-script.php
 
 ### Kill switch
 
-If your script does not already contain a kill-switch statement, `embed.php`
-will automatically inject one after the embed region. This allows tests to run
-the script without executing the real work below:
+If your script does not already contain a kill-switch statement, `embed.php` will automatically inject one after the embed region. This allows tests to run the script without executing the real work below:
 
 ```php
 // Kill switch — stop here when running under tests.
@@ -687,10 +745,12 @@ php embed.php --no-killswitch my-script.php
 <summary>Embed into starter script</summary>
 
 ```bash
+BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
+
 # Download Prompty.php, embed.php, and the starter template.
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/embed.php
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/starter.php
+curl -LO $BASE/Prompty.php
+curl -LO $BASE/embed.php
+curl -LO $BASE/starter.php
 
 # Rename the starter to your script name.
 mv starter.php my-script.php
@@ -705,9 +765,11 @@ php embed.php my-script.php
 <summary>Embed into custom script</summary>
 
 ```bash
+BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
+
 # Download Prompty.php and embed.php.
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/embed.php
+curl -LO $BASE/Prompty.php
+curl -LO $BASE/embed.php
 
 # Add markers in your script around the require_once line:
 #
@@ -727,8 +789,10 @@ php embed.php my-script.php
 <summary>Update Prompty</summary>
 
 ```bash
+BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
+
 # Download the new Prompty.php, overwriting the old one.
-curl -LO https://github.com/AlexSkrypnyk/prompty/releases/latest/download/Prompty.php
+curl -LO $BASE/Prompty.php
 
 # Re-run the embedder. Code outside the markers is preserved.
 php embed.php my-script.php
@@ -739,13 +803,13 @@ php embed.php --source /path/to/new/Prompty.php my-script.php
 
 </details>
 
-## Maintenance
+## Contributing
 
-```bash
-composer install
-composer lint
-composer test
-```
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup, the linting and testing commands, the playground scripts, and the release process.
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability and how to verify a downloaded release.
 
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported versions
+
+Prompty is pre-1.0, and only the [latest release](https://github.com/AlexSkrypnyk/prompty/releases/latest) is supported. Fixes land in a new release rather than being backported, so if you're on an older tag, upgrading is the fix.
+
+## Reporting a vulnerability
+
+Please don't open a public issue for a security problem.
+
+Use GitHub's private reporting instead - go to the [Security tab](https://github.com/AlexSkrypnyk/prompty/security/advisories/new) and choose "Report a vulnerability". That opens a private thread visible only to the maintainers. If that isn't available to you, email <prompty@alexskrypnyk.com>.
+
+Helpful things to include:
+
+- What the issue is, and which file or function it's in.
+- The version or commit you're on.
+- Steps to reproduce, ideally as a short script.
+- What an attacker could actually do with it.
+
+You'll get an acknowledgement within a few days. If the report is confirmed, we'll agree a disclosure timeline with you and credit you in the advisory unless you'd rather stay anonymous.
+
+## Verifying a release
+
+Every release ships a `SHA256SUMS` file covering all assets, plus a detached GPG signature `SHA256SUMS.asc`. The signing key's public half is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository.
+
+Because Prompty is designed to be copied or embedded directly into your own script, verifying the download before you paste it in is worth the 20 seconds:
+
+```bash
+BASE=https://github.com/AlexSkrypnyk/prompty/releases/latest/download
+RAW=https://raw.githubusercontent.com/AlexSkrypnyk/prompty/main
+
+curl -LO $BASE/Prompty.php
+curl -LO $BASE/SHA256SUMS
+curl -LO $BASE/SHA256SUMS.asc
+curl -LO $RAW/PUBLIC_KEY.asc
+
+gpg --import PUBLIC_KEY.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+`--ignore-missing` lets the check pass when you've only downloaded some of the assets. Drop it if you've pulled all of them.
+
+The release workflow performs this same verification itself after uploading, so a release that fails it never ships.
+
+## Scope
+
+Prompty reads keystrokes from a stream and writes ANSI escape sequences to stdout. It runs `stty` through the shell to put the terminal into raw mode and to restore it afterwards, using only values it read back from `stty -g` itself - never anything supplied by a caller or an environment variable.
+
+The library performs no network access, writes no files, and evaluates no user input as code.
+
+`embed.php` is a build-time tool with a wider footprint. It reads a class file, rewrites it, writes the result to a path you name, and then shells out: to Rector if it's installed, to `php -l` to check the output parses, and to `php <your-script>` to confirm the embedded result actually runs. That last step executes the target script, so only point `embed.php` at scripts you trust. The run is guarded by the [kill switch](README.md#kill-switch): `embed.php` only runs a script that has one, and the kill switch returns before the script's real work unless `SHOULD_PROCEED` is set.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,11 @@ You'll get an acknowledgement within a few days. If the report is confirmed, we'
 
 ## Verifying a release
 
-Every release ships a `SHA256SUMS` file covering all assets, plus a detached GPG signature `SHA256SUMS.asc`. The signing key's public half is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository.
+Every release ships a `SHA256SUMS` file covering all assets, plus a detached GPG signature `SHA256SUMS.asc`. The signing key's public half is [`PUBLIC_KEY.asc`](PUBLIC_KEY.asc) in this repository, and its fingerprint is:
+
+```text
+755E 824E 80F8 4913 5F5F  4043 E71E DB25 C4F6 D89D
+```
 
 Because Prompty is designed to be copied or embedded directly into your own script, verifying the download before you paste it in is worth the 20 seconds:
 
@@ -34,6 +38,9 @@ curl -LO $BASE/SHA256SUMS
 curl -LO $BASE/SHA256SUMS.asc
 curl -LO $RAW/PUBLIC_KEY.asc
 
+# Check the fingerprint against the one above before trusting the key.
+gpg --show-keys --with-fingerprint PUBLIC_KEY.asc
+
 gpg --import PUBLIC_KEY.asc
 gpg --verify SHA256SUMS.asc SHA256SUMS
 sha256sum --ignore-missing -c SHA256SUMS
@@ -42,6 +49,12 @@ sha256sum --ignore-missing -c SHA256SUMS
 `--ignore-missing` lets the check pass when you've only downloaded some of the assets. Drop it if you've pulled all of them.
 
 The release workflow performs this same verification itself after uploading, so a release that fails it never ships.
+
+### What this does and does not prove
+
+Worth being clear about the limits. The key and the fingerprint above both live in this repository, so on their own they prove the release was signed by whoever controls the repository - not that it was signed by the maintainer. Anyone who compromised the repository or the maintainer's account could replace the key, the signature and this page together, and a first-time download would still verify.
+
+What the fingerprint does buy you is continuity. Record it the first time, check it on every later download, and a key swap becomes visible immediately - which is the attack this actually defends against. If it ever changes without a corresponding note in the release notes, treat the release as suspect and [get in touch](#reporting-a-vulnerability) before running anything.
 
 ## Scope
 

--- a/embed.php
+++ b/embed.php
@@ -561,7 +561,6 @@ if ($compact && $class_start !== NULL) {
       $after_is_word = preg_match('/[a-zA-Z0-9_$\\\\]/', $after_first);
 
       if ($before_is_word && $after_is_word) {
-        // Space is needed between two word characters.
         $whitespace_output .= ' ';
       }
       continue;

--- a/tests/phpunit/Unit/Prompty/PromptyWalkFlowTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyWalkFlowTest.php
@@ -319,7 +319,6 @@ final class PromptyWalkFlowTest extends PromptyTestCase {
     $p = $this->createAndSetInstance();
 
     // Two steps at depth 1. The second has a __condition that passes.
-    // This tests the sibling condition check path (line 931-933).
     $steps = [
       'first' => $this->resolvedStep('val1'),
       'second' => [


### PR DESCRIPTION
## Summary

A repo-polish pass that closes the gap between the code and its documentation, and tidies a few source-level rough edges. The README's test-harness example did not work: it referenced `\PromptyTestTrait` and `\Prompty::results()`, neither of which exists at that path, instead of the namespaced `AlexSkrypnyk\Prompty\*` classes. Several public API surfaces were undocumented (`promptyRun()`, `embed.php --stdout`, `Prompty::version()`, `intro()`, `outro()`, `output()`, the PHP 8.2+ requirement, the GPG-signed `SHA256SUMS` release assets), as were two behaviours a caller can be caught by: submitting an empty `text` input returns the placeholder as the answer, and `flow()` returns `null` on cancellation.

Contributor-facing setup and process notes move out of the README into a new `CONTRIBUTING.md`, and a new `SECURITY.md` covers vulnerability reporting and release verification. `CLAUDE.md` is corrected to match the current `playground/` contents, the real behaviour of `composer reset`, and the PHP target `rector.php` actually sets. On the source side, a few stale or redundant comments are gone and `Prompty.php` now spaces `return` statements consistently.

No behaviour changes anywhere. The full suite (342 tests, 832 assertions) and `composer lint` (PHPCS, PHPStan level 9, Rector) pass unchanged.

## Changes

### README

- Rewrote the test-harness example to use `AlexSkrypnyk\Prompty\Prompty` and `AlexSkrypnyk\Prompty\PromptyTestTrait`, and added a `promptyRun()` example alongside the existing `promptyRunScript()` one, with a note on the `result` and `output` keys each helper returns.
- Added an "Other methods" table covering `Prompty::results()`, `config()`, `version()`, `intro()`, `outro()` and `output()`, and an "Options" table under Embedding covering `--source`, `--compact`, `--stdout` and `--no-killswitch`. `--stdout` was entirely undocumented despite being what the release workflow uses to build both minified assets.
- Added a "Verifying a download" section documenting the GPG-signed `SHA256SUMS` and `SHA256SUMS.asc` release assets, including the signing key fingerprint, and stated the PHP 8.2+ requirement in Installation.
- Documented that an empty `text` submission returns the `placeholder` as the answer, that `flow()` returns `null` on cancellation, and that `PROMPTY_*` multiselect discovery reads a comma-separated list.
- Replaced the `Maintenance` section with `Contributing` and `Security` pointers, fixed the logo anchor (`href=""` pointed nowhere), reflowed prose to one line per paragraph, brought every code example under 80 columns, and factored the repeated release-download URLs into `BASE` and `RAW` shell variables.

### New files

- `CONTRIBUTING.md`: local setup, the PHP matrix CI runs against, the `composer` command table, the three code-quality tools and what each enforces, coding conventions, test layout and data-provider naming, the full `playground/` script list with what each demonstrates and which accept `--no-unicode` / `--no-ansi`, the demo-content theme rule, asset regeneration via `.util/update-assets.php`, and the release workflow.
- `SECURITY.md`: supported-versions policy, private vulnerability reporting through GitHub's Security tab with an email fallback, the release-verification steps, a "What this does and does not prove" section on the limits of a same-repository signing key, and a "Scope" section describing what `Prompty.php` and `embed.php` actually touch at runtime.

### Source

- `Prompty.php`: blank line before `return` statements that followed a block, matching what the rest of the file and the other source files already did. Reworded the `version()` docblock to drop a `sed` detail owned by the release workflow.
- `PromptyTestTrait.php`, `embed.php`, `tests/phpunit/Unit/Prompty/PromptyWalkFlowTest.php`: removed comments that restated the code directly below them, duplicated their own docblock, or pinned a line number in another file that no longer pointed at anything.
- `.util/update-assets.php`: `drainPipes()`'s docblock claimed it returns only once both pipes reach EOF. The `stream_select()` failure path breaks out early and returns partial output, so the guarantee is now qualified.

### CLAUDE.md

- The playground list named 3 of the 10 scripts that exist; it now points at `CONTRIBUTING.md` for the full list rather than carrying a second copy that drifts again.
- `composer reset` was described as "rm vendor/, reinstall"; it removes `vendor/`, `vendor-bin/` and `composer.lock`, and reinstalls nothing.
- Rector was described as "PHP 8.2/8.3 modernization"; `rector.php` sets `php82` only.

## Before / After

```
┌─ BEFORE ────────────────────────────────────────────────────────────┐
│                                                                     │
│  README.md - test harness example (does not run)                    │
│    class MyTest extends TestCase {                                  │
│      use PromptyTestTrait;        -> \PromptyTestTrait, undefined   │
│      $results = \Prompty::results();  -> \Prompty, undefined        │
│    }                                                                │
│                                                                     │
│  Undocumented API                                                   │
│    promptyRun()   embed.php --stdout   Prompty::version()           │
│    intro()  outro()  output()  PHP 8.2+  SHA256SUMS + GPG           │
│                                                                     │
│  Undocumented behaviour                                             │
│    empty text submit -> returns placeholder                         │
│    flow() cancelled  -> returns null                                │
│                                                                     │
│  Audience mixed into one file                                       │
│    README.md ── ## Maintenance (install / lint / test)              │
│                                                                     │
│  CLAUDE.md drift                                                    │
│    playground: 3 of 10 scripts listed                               │
│    composer reset  # rm vendor/, reinstall                          │
│    Rector - PHP 8.2/8.3 modernization                               │
│                                                                     │
└─────────────────────────────────────────────────────────────────────┘

┌─ AFTER ─────────────────────────────────────────────────────────────┐
│                                                                     │
│  README.md - test harness example (runs)                            │
│    use AlexSkrypnyk\Prompty\Prompty;                                │
│    use AlexSkrypnyk\Prompty\PromptyTestTrait;                       │
│    $run = $this->promptyRun(fn(): mixed => Prompty::flow(...));     │
│    $this->assertSame('plum compote', $run['result']['dish']);       │
│                                                                     │
│  Documented                                                         │
│    "Other methods" table      Embedding "Options" table             │
│    "Verifying a download" + key fingerprint                         │
│    2 behaviour notes          PHP 8.2+ requirement                  │
│                                                                     │
│  Audience routed                                                    │
│    README.md ──── ## Contributing ──┐                               │
│              └─── ## Security ──────┼──┐                            │
│    CONTRIBUTING.md  <───────────────┘  │  setup, commands, tests,   │
│                                        │  playground, releases      │
│    SECURITY.md      <──────────────────┘  reporting, verification   │
│                                                                     │
│  CLAUDE.md accurate                                                 │
│    playground: pointer to CONTRIBUTING.md (single source)           │
│    composer reset  # rm vendor/, vendor-bin/, composer.lock         │
│    Rector - PHP 8.2 modernization                                   │
│                                                                     │
└─────────────────────────────────────────────────────────────────────┘
```
