### PR TITLE
[#68] Made '--no-killswitch' skip the post-embed verification run and added '--no-verify'.

### DIFF
--- a/.util/check-embed.php
+++ b/.util/check-embed.php
@@ -75,10 +75,8 @@ function main(): void {
  *   When the embedder fails or writes nothing.
  */
 function build(string $project_dir, string $target): string {
-  // Redirect stdin so the embedder takes its non-interactive path. Given a
-  // TTY it hands the terminal to the embedded script and waits for keys.
   $command = sprintf(
-    'php %s %s %s < /dev/null 2>&1',
+    'php %s --no-verify %s %s 2>&1',
     escapeshellarg($project_dir . '/embed.php'),
     escapeshellarg($project_dir . '/' . SOURCE_SCRIPT),
     escapeshellarg($target),

--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ See [`starter.php`](starter.php) for an example with markers already in place. F
 | `--compact`       | Collapse the class onto a single line and shorten internal names, for a smaller output.   |
 | `--stdout`        | Write the processed class as a standalone PHP file instead of embedding into a script.    |
 | `--no-killswitch` | Skip injecting the kill switch block and the post-embed verification run.                 |
+| `--no-verify`     | Skip the post-embed verification run, still injecting the kill switch block.              |
 
 ```bash
 php embed.php --compact my-script.php
@@ -735,7 +736,7 @@ php embed.php --source /path/to/new/Prompty.php my-script.php
 If your script does not already contain a kill-switch statement, `embed.php` will automatically inject one after the embed region. This allows tests to run the script without executing the real work below:
 
 ```php
-// Kill switch — stop here when running under tests.
+// Kill switch - stop here when running under tests.
 // In production, set SHOULD_PROCEED=1 to continue past this point.
 if (!getenv('SHOULD_PROCEED')) {
   return;
@@ -746,6 +747,18 @@ Use `--no-killswitch` to skip the injection:
 
 ```bash
 php embed.php --no-killswitch my-script.php
+```
+
+### Verification run
+
+Once the file is written, `embed.php` runs it to confirm the embedded class works. In a terminal the run takes over the keyboard so the flow can be stepped through by hand; otherwise it pipes a few newlines in and discards the output.
+
+The kill switch is what keeps that run from reaching the real work, so the run only happens when the file ends up with one. `--no-killswitch` therefore skips the run as well as the injection.
+
+Use `--no-verify` to embed without running the result while still injecting the kill switch - for build steps, CI jobs, and scripts that regenerate an embedded file:
+
+```bash
+php embed.php --no-verify my-script.php
 ```
 
 ### For AI agents

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "scripts": {
         "check-embed-playground": "php .util/check-embed.php",
-        "embed-playground": "php embed.php playground/flow-embed.php playground/flow-embed.dist.php",
+        "embed-playground": "php embed.php --no-verify playground/flow-embed.php playground/flow-embed.dist.php",
         "lint": [
             "phpcs",
             "phpstan",

--- a/embed.php
+++ b/embed.php
@@ -31,6 +31,7 @@ define('EMBED_MARKER_END', '@embed-end');
 $compact = FALSE;
 $stdout = FALSE;
 $no_killswitch = FALSE;
+$no_verify = FALSE;
 $source_override = NULL;
 $positional = [];
 
@@ -43,6 +44,9 @@ for ($arg_i = 1; $arg_i < $argc; $arg_i++) {
   }
   elseif ($argv[$arg_i] === '--no-killswitch') {
     $no_killswitch = TRUE;
+  }
+  elseif ($argv[$arg_i] === '--no-verify') {
+    $no_verify = TRUE;
   }
   elseif ($argv[$arg_i] === '--source') {
     $arg_i++;
@@ -80,6 +84,8 @@ Options:
                     of embedding into a target script.
   --no-killswitch   Skip injecting the kill switch block and post-embed
                     verification run.
+  --no-verify       Skip the post-embed verification run, still injecting the
+                    kill switch block.
 
 Re-embedding:
   Running embed.php on a previously embedded script replaces the embedded region
@@ -716,8 +722,16 @@ $final_has_killswitch = $final !== FALSE && str_contains($final, "if (!getenv('S
 
 if (!$final_has_killswitch) {
   fwrite(STDERR, sprintf('Warning: No kill switch found in the target file. Please test the embedded script manually.%s', PHP_EOL));
+  exit(0);
 }
-elseif (posix_isatty(STDIN)) {
+
+// Verification runs the embedded script, and --no-killswitch leaves it with
+// nothing to stop before the real work.
+if ($no_killswitch || $no_verify) {
+  exit(0);
+}
+
+if (posix_isatty(STDIN)) {
   echo sprintf('Verifying embedded script (interactive input required)...%s', PHP_EOL);
 
   $verify_exit = 0;

--- a/tests/phpunit/Functional/EmbedScriptTest.php
+++ b/tests/phpunit/Functional/EmbedScriptTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\Prompty\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -211,17 +212,6 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->assertRectorClean($output_path);
   }
 
-  public function testEmbedKillswitchAlreadyPresent(): void {
-    $target = $this->prepareTarget();
-
-    $this->runEmbed($target);
-
-    $content = file_get_contents($target);
-    $this->assertIsString($content);
-
-    $this->assertSame(1, substr_count($content, "if (!getenv('SHOULD_PROCEED'))"), 'Kill switch should appear exactly once.');
-  }
-
   public function testEmbedKillswitchInjected(): void {
     $target = $this->prepareTargetWithoutKillswitch();
 
@@ -240,32 +230,39 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->assertGreaterThan($embed_end_pos, $killswitch_pos);
   }
 
-  public function testEmbedRunsVerification(): void {
-    $target = $this->prepareTarget();
+  #[DataProvider('dataProviderEmbedKillswitchAndVerification')]
+  public function testEmbedKillswitchAndVerification(bool $has_killswitch, string $flags, bool $expect_killswitch, bool $expect_verification): void {
+    $target = $has_killswitch ? $this->prepareTarget() : $this->prepareTargetWithoutKillswitch();
 
-    $keystrokes = $this->keys(
-      'plum compote', self::KEYS['ENTER'],
-      self::KEYS['DOWN'], self::KEYS['ENTER'],
-      self::KEYS['SPACE'], self::KEYS['ENTER'],
-      self::KEYS['ENTER'],
-    );
+    $args = $flags === '' ? [] : explode(' ', $flags);
+    $args[] = $target;
 
-    $r = $this->runWithKeystrokes('php ' . escapeshellarg(self::$root . '/embed.php') . ' ' . escapeshellarg($target), $keystrokes);
-    $this->assertSame(0, $r['exit_code'], 'Embed with verification failed: ' . $r['stderr']);
-    $this->assertStringContainsString('Verifying', $r['stdout']);
-  }
-
-  public function testEmbedNoKillswitchFlag(): void {
-    $target = $this->prepareTargetWithoutKillswitch();
-
-    $embed_output = $this->runEmbedWithOutput('--no-killswitch', $target);
+    $embed_output = $this->runEmbedWithOutput(...$args);
 
     $content = file_get_contents($target);
     $this->assertIsString($content);
 
-    $this->assertStringNotContainsString("if (!getenv('SHOULD_PROCEED'))", $content);
-    $this->assertStringContainsString('no kill switch', strtolower($embed_output));
-    $this->assertStringNotContainsString('Verifying', $embed_output);
+    $this->assertSame($expect_killswitch ? 1 : 0, substr_count($content, "if (!getenv('SHOULD_PROCEED'))"), 'Kill switch count in the embedded file.');
+    $this->assertSame($expect_verification, str_contains($embed_output, 'Verifying'), 'Verification run in the embedder output.');
+    $this->assertSame(!$expect_killswitch, str_contains(strtolower($embed_output), 'no kill switch'), 'Missing kill switch warning in the embedder output.');
+  }
+
+  public static function dataProviderEmbedKillswitchAndVerification(): \Iterator {
+    yield 'own kill switch' => [TRUE, '', TRUE, TRUE];
+
+    yield 'own kill switch, --no-killswitch' => [TRUE, '--no-killswitch', TRUE, FALSE];
+
+    yield 'own kill switch, --no-verify' => [TRUE, '--no-verify', TRUE, FALSE];
+
+    yield 'own kill switch, both flags' => [TRUE, '--no-killswitch --no-verify', TRUE, FALSE];
+
+    yield 'no kill switch' => [FALSE, '', TRUE, TRUE];
+
+    yield 'no kill switch, --no-killswitch' => [FALSE, '--no-killswitch', FALSE, FALSE];
+
+    yield 'no kill switch, --no-verify' => [FALSE, '--no-verify', TRUE, FALSE];
+
+    yield 'no kill switch, both flags' => [FALSE, '--no-killswitch --no-verify', FALSE, FALSE];
   }
 
   public function testSourceFlag(): void {
@@ -372,7 +369,7 @@ final class EmbedScriptTest extends FunctionalTestCase {
     $this->processRun('php', [self::$root . '/embed.php']);
     $this->assertProcessFailed();
 
-    $this->assertProcessAnyOutputContains(['Usage:', '--source', '--compact', '--stdout', '--no-killswitch', 'Re-embedding', 'Arguments:', 'Options:']);
+    $this->assertProcessAnyOutputContains(['Usage:', '--source', '--compact', '--stdout', '--no-killswitch', '--no-verify', 'Re-embedding', 'Arguments:', 'Options:']);
   }
 
   public function testEmbedErrors(): void {


### PR DESCRIPTION
Closes #68

## Summary

`embed.php` documented `--no-killswitch` as skipping both the kill switch injection and the post-embed verification run, but the verification block only checked whether the final file contained a kill switch (`$final_has_killswitch`), never the flag itself. On a target that already declared its own kill switch, passing `--no-killswitch` skipped injection as documented but silently left verification running anyway. This change gates verification on the flags directly and adds a new `--no-verify` flag that skips the run independently of kill switch injection, for build steps and CI jobs that need to embed without executing the result.

## Changes

- `embed.php`: parses a new `--no-verify` flag alongside `--no-killswitch`. The verification block now exits immediately after the missing-kill-switch warning, then checks `$no_killswitch || $no_verify` before running the interactive or piped verification path, so both flags reliably suppress the run regardless of whether the target already carried its own kill switch.
- `README.md`: adds `--no-verify` to the options table and a new "Verification run" section explaining when the run happens and how `--no-killswitch` and `--no-verify` each affect it. Also corrects the quoted kill switch block, which used an em dash where the injected block uses a hyphen.
- `composer.json`: the `embed-playground` script now passes `--no-verify` so rebuilding the playground demo no longer executes it.
- `.util/check-embed.php`: the `check-embed-playground` check now passes `--no-verify` to `embed.php` instead of redirecting `stdin` from `/dev/null` to fake a non-interactive run.
- `tests/phpunit/Functional/EmbedScriptTest.php`: replaces three overlapping kill switch and verification tests with one data-provider-driven test covering every combination of an existing kill switch, `--no-killswitch`, and `--no-verify`, and adds `--no-verify` to the expected usage-output assertion. `testEmbedKillswitchInjected` stays, since it asserts the injected block's position relative to `@embed-end`, which the matrix does not cover.

## Before / After

```
┌────────────────────────────┬─────────────────┬──────────────────────────┬──────────────────────────┐
│ Target has own kill switch │ Flags passed    │ Verify ran BEFORE        │ Verify ran AFTER         │
├────────────────────────────┼─────────────────┼──────────────────────────┼──────────────────────────┤
│ no                         │ (none)          │ yes (injects, then runs) │ yes (injects, then runs) │
│ no                         │ --no-killswitch │ no (nothing to inject)   │ no (nothing to inject)   │
│ no                         │ --no-verify     │ n/a (flag did not exist) │ no (injects, skips run)  │
│ yes                        │ (none)          │ yes                      │ yes                      │
│ yes                        │ --no-killswitch │ YES <- bug               │ no                       │
│ yes                        │ --no-verify     │ n/a (flag did not exist) │ no                       │
│ yes                        │ both flags      │ n/a (flag did not exist) │ no                       │
└────────────────────────────┴─────────────────┴──────────────────────────┴──────────────────────────┘
```
