### PR TITLE
[#94] Scoped a flow's configuration arguments to that flow.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ The [`playground/`](playground) directory holds runnable demos - the quickest wa
 | `flow-nested.php`             | A nested flow with conditionals, 3 levels deep.     |
 | `flow-config.php`             | A flow with `configure()` applied beforehand.       |
 | `flow-multiple.php`           | Several flows, and a standalone widget between them.|
+| `flow-config-scope.php`       | How long a flow's own configuration lasts.          |
 | `flow-embed.php`              | The flow the embedder is tested against.            |
 
 ```bash
@@ -97,7 +98,7 @@ Most of them accept `--no-unicode` and `--no-ansi` to force a display mode:
 php playground/flow.php --no-unicode --no-ansi
 ```
 
-`flow-config.php` and `flow-multiple.php` set their display mode in code instead, so the flags do nothing there.
+`flow-config.php` and `flow-multiple.php` set their display mode in code instead, and `flow-config-scope.php` is about configuration lifetime rather than display, so the flags do nothing in those three.
 
 ### The embedded demo
 

--- a/Prompty.php
+++ b/Prompty.php
@@ -23,6 +23,19 @@ namespace AlexSkrypnyk\Prompty;
  *
  * This notice must be included in all copies of this file, including when
  * used as a part of other files.
+ *
+ * @phpstan-type PromptyConfig array{
+ *   symbols_unicode: array<string, string>,
+ *   symbols_ascii: array<string, string>,
+ *   colors: array<string, string>,
+ *   spacing: array<string, string>,
+ *   labels: array<string, string>,
+ *   unicode: bool|null,
+ *   ansi: bool|null,
+ *   env_prefix: string,
+ *   truthy: list<string>,
+ *   falsy: list<string>,
+ * }
  */
 class Prompty {
 
@@ -232,6 +245,58 @@ class Prompty {
   }
 
   /**
+   * Resolves the symbol and colour sets from the unicode and ANSI settings.
+   */
+  protected function resolveDisplay(): void {
+    $this->cfgSymbols = $this->cfgUnicode ? $this->cfgSymbolsUnicode : $this->cfgSymbolsAscii;
+    $this->cfgColors = $this->cfgAnsi ? $this->cfgColorsDefault : array_fill_keys(array_keys($this->cfgColorsDefault), '');
+  }
+
+  /**
+   * Captures the configuration a flow can override.
+   *
+   * @return PromptyConfig
+   *   The values in force, keyed as configure() names them.
+   */
+  protected function configSnapshot(): array {
+    return [
+      'symbols_unicode' => $this->cfgSymbolsUnicode,
+      'symbols_ascii' => $this->cfgSymbolsAscii,
+      'colors' => $this->cfgColorsDefault,
+      'spacing' => $this->cfgSpacing,
+      'labels' => $this->cfgLabels,
+      'unicode' => $this->cfgUnicode,
+      'ansi' => $this->cfgAnsi,
+      'env_prefix' => $this->cfgEnvPrefix,
+      'truthy' => $this->cfgTruthy,
+      'falsy' => $this->cfgFalsy,
+    ];
+  }
+
+  /**
+   * Puts a captured configuration back in force.
+   *
+   * The values are assigned rather than merged, so a key a flow added is gone
+   * as well as one it changed.
+   *
+   * @param PromptyConfig $snapshot
+   *   A snapshot from configSnapshot().
+   */
+  protected function configRestore(array $snapshot): void {
+    $this->cfgSymbolsUnicode = $snapshot['symbols_unicode'];
+    $this->cfgSymbolsAscii = $snapshot['symbols_ascii'];
+    $this->cfgColorsDefault = $snapshot['colors'];
+    $this->cfgSpacing = $snapshot['spacing'];
+    $this->cfgLabels = $snapshot['labels'];
+    $this->cfgUnicode = $snapshot['unicode'];
+    $this->cfgAnsi = $snapshot['ansi'];
+    $this->cfgEnvPrefix = $snapshot['env_prefix'];
+    $this->cfgTruthy = $snapshot['truthy'];
+    $this->cfgFalsy = $snapshot['falsy'];
+    $this->resolveDisplay();
+  }
+
+  /**
    * Get the resolved configuration array.
    *
    * @return array<string, mixed>
@@ -350,8 +415,7 @@ class Prompty {
     if ($falsy !== NULL) {
       $p->cfgFalsy = $falsy;
     }
-    $p->cfgSymbols = $p->cfgUnicode ? $p->cfgSymbolsUnicode : $p->cfgSymbolsAscii;
-    $p->cfgColors = $p->cfgAnsi ? $p->cfgColorsDefault : array_fill_keys(array_keys($p->cfgColorsDefault), '');
+    $p->resolveDisplay();
   }
 
   /**
@@ -415,6 +479,9 @@ class Prompty {
     ?array $truthy = NULL,
     ?array $falsy = NULL,
   ): ?array {
+    $p = static::instance();
+    $snapshot = NULL;
+
     if ($symbols_unicode !== NULL
       || $symbols_ascii !== NULL
       || $colors !== NULL
@@ -425,9 +492,10 @@ class Prompty {
       || $env_prefix !== NULL
       || $truthy !== NULL
       || $falsy !== NULL) {
+      $snapshot = $p->configSnapshot();
       static::configure($symbols_unicode, $symbols_ascii, $colors, $spacing, $labels, $unicode, $ansi, $env_prefix, $truthy, $falsy);
     }
-    $p = static::instance();
+
     $p->results = [];
     static::$inFlow = TRUE;
 
@@ -478,6 +546,10 @@ class Prompty {
       $p->teardownTty();
       $p->pending = NULL;
       static::$inFlow = FALSE;
+
+      if ($snapshot !== NULL) {
+        $p->configRestore($snapshot);
+      }
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ And a nested flow:
 
 Configure globally with `Prompty::configure()` or per-flow via named arguments on `Prompty::flow()`. All parameters are optional — pass only what you want to override. Per-flow config merges on top of global.
 
+A per-flow argument lasts as long as the flow. Whether the flow completes, is cancelled, or throws, the configuration it found is back in force when it returns, so the next flow sees the global settings rather than the last flow's. `Prompty::configure()` is the way to change something for the rest of the process.
+
 ```php
 // Global.
 Prompty::configure(

--- a/playground/flow-config-scope.php
+++ b/playground/flow-config-scope.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @file
+ * Playground - how long a flow's configuration lasts.
+ *
+ * The configuration arguments on flow() are scoped to that call, the way
+ * intro, outro and numbering are. They are not a shorthand for configure().
+ *
+ * Three flows run here:
+ *
+ * 1. One that asks for its own spacing, labels and environment prefix.
+ * 2. One that asks for nothing, and renders with the configuration that was
+ *    in force before the first flow rather than the one the first flow set.
+ * 3. One that runs after configure(), which is the way to change something
+ *    for the rest of the process.
+ *
+ * The configuration is printed between the flows, so the difference is
+ * readable without having to compare glyphs.
+ *
+ * phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../Prompty.php';
+
+use AlexSkrypnyk\Prompty\Prompty;
+
+/**
+ * Print the configuration values these flows change.
+ *
+ * @param string $when
+ *   What has happened by this point.
+ */
+function report(string $when): void {
+  $config = Prompty::config();
+  $spacing = is_array($config['spacing'] ?? NULL) ? $config['spacing'] : [];
+  $labels = is_array($config['labels'] ?? NULL) ? $config['labels'] : [];
+
+  $indent = is_string($spacing['indent'] ?? NULL) ? $spacing['indent'] : '';
+  $yes = is_string($labels['yes'] ?? NULL) ? $labels['yes'] : '';
+  $prefix = is_string($config['env_prefix'] ?? NULL) ? $config['env_prefix'] : '';
+
+  echo PHP_EOL . $when . PHP_EOL;
+  echo '  indent:     "' . $indent . '"' . PHP_EOL;
+  echo '  yes label:  "' . $yes . '"' . PHP_EOL;
+  echo '  env prefix: "' . $prefix . '"' . PHP_EOL . PHP_EOL;
+}
+
+report('Before any flow ran:');
+
+// This flow asks for its own spacing, labels and prefix. Answers come from
+// KITCHEN_DISH rather than PROMPTY_DISH while it runs.
+$first = Prompty::flow(fn(): array => [
+  'dish' => Prompty::text('Dish name', placeholder: 'pear tart'),
+],
+  intro: 'A flow with its own configuration',
+  outro: 'Dish noted.',
+  cancelled: 'Cancelled.',
+  spacing: ['indent' => '....'],
+  labels: ['yes' => 'Aye', 'no' => 'Nay'],
+  env_prefix: 'KITCHEN_',
+);
+
+if ($first === NULL) {
+  exit(0);
+}
+
+report('After that flow returned, its configuration is gone:');
+
+// This flow asks for nothing, so it renders the way the first flow found the
+// world rather than the way the first flow left it.
+$second = Prompty::flow(fn(): array => [
+  'course' => Prompty::select('Course', options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert']),
+],
+  intro: 'A flow that asks for nothing',
+  outro: 'Course noted.',
+  cancelled: 'Cancelled.',
+);
+
+if ($second === NULL) {
+  exit(0);
+}
+
+// configure() writes to the singleton, so this one does last.
+Prompty::configure(labels: ['yes' => 'Aye', 'no' => 'Nay']);
+
+report('After configure(), the change stays:');
+
+$third = Prompty::flow(fn(): array => [
+  'send' => Prompty::confirm('Send order?'),
+],
+  intro: 'A flow after configure()',
+  outro: 'Order sent!',
+  cancelled: 'Cancelled.',
+);
+
+if ($third === NULL) {
+  exit(0);
+}
+
+report('And it is still in force after that flow too:');

--- a/playground/flow-multiple.php
+++ b/playground/flow-multiple.php
@@ -4,8 +4,12 @@
  * @file
  * Playground - multiple flows in the same script.
  *
- * Demonstrates that the singleton is reused across flows. Each flow()
- * call resets results but preserves the instance and its configuration.
+ * Demonstrates that the singleton is reused across flows. Each flow() call
+ * resets the results but keeps the instance, so anything configure() set is
+ * still in force. A flow's own configuration arguments are not: they last as
+ * long as that flow, which is why the ASCII mode both flows here render in is
+ * set with configure() rather than passed to the first of them. See
+ * flow-config-scope.php for that difference on its own.
  *
  * Standalone widgets can be called between flows too.
  *
@@ -18,6 +22,8 @@ require __DIR__ . '/../Prompty.php';
 
 use AlexSkrypnyk\Prompty\Prompty;
 
+Prompty::configure(unicode: FALSE);
+
 $basics = Prompty::flow(fn(): array => [
   'dish' => Prompty::text('Dish name', placeholder: 'pear tart'),
   'course' => Prompty::select('Course', options: ['starter' => 'Starter', 'main' => 'Main', 'dessert' => 'Dessert']),
@@ -25,7 +31,6 @@ $basics = Prompty::flow(fn(): array => [
   intro: 'Step 1: The dish',
   outro: 'Dish noted.',
   cancelled: 'Dish selection cancelled.',
-  unicode: FALSE,
 );
 
 if ($basics === NULL) {

--- a/tests/phpunit/Unit/Prompty/PromptyFlowConfigScopeTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyFlowConfigScopeTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that a flow's configuration arguments last only as long as the flow.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyFlowConfigScopeTest extends PromptyTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->createAndSetInstance(['unicode' => TRUE, 'ansi' => TRUE]);
+  }
+
+  /**
+   * The steps every flow in this test runs.
+   *
+   * @return \Closure
+   *   A callable returning one text step that resolves from the environment.
+   */
+  protected static function steps(): \Closure {
+    return fn(): array => ['dish' => Prompty::text('Dish name')];
+  }
+
+  #[DataProvider('dataProviderConfigIsRestored')]
+  public function testConfigIsRestored(\Closure $run, string $key): void {
+    $this->setEnvVars(['dish' => 'plum compote']);
+    $before = Prompty::config();
+
+    $this->captureOutput($run);
+
+    $this->assertSame($before[$key], Prompty::config()[$key]);
+  }
+
+  public static function dataProviderConfigIsRestored(): \Iterator {
+    $steps = self::steps();
+
+    yield 'unicode' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, unicode: FALSE);
+      },
+      'unicode',
+    ];
+
+    yield 'ansi' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, ansi: FALSE);
+      },
+      'ansi',
+    ];
+
+    yield 'env prefix' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, env_prefix: 'OTHER_');
+      },
+      'env_prefix',
+    ];
+
+    yield 'labels' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, labels: ['yes' => 'Aye']);
+      },
+      'labels',
+    ];
+
+    yield 'truthy' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, truthy: ['aye']);
+      },
+      'truthy',
+    ];
+
+    yield 'falsy' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, falsy: ['nay']);
+      },
+      'falsy',
+    ];
+
+    yield 'spacing' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, spacing: ['indent' => '....']);
+      },
+      'spacing',
+    ];
+
+    yield 'unicode symbols' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, symbols_unicode: ['bar' => '!']);
+      },
+      'symbols_unicode',
+    ];
+
+    yield 'colors' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, colors: ['cyan' => '']);
+      },
+      'colors',
+    ];
+  }
+
+  public function testSecondFlowSeesTheGlobalConfiguration(): void {
+    $this->setEnvVars(['dish' => 'plum compote']);
+    $steps = self::steps();
+
+    $first = $this->captureOutput(function () use ($steps): void {
+      Prompty::flow($steps, spacing: ['indent' => '....'], unicode: FALSE);
+    });
+
+    $second = $this->captureOutput(function () use ($steps): void {
+      Prompty::flow($steps);
+    });
+
+    $this->assertStringContainsString('....', $first);
+    $this->assertStringNotContainsString('....', $second);
+    $this->assertStringContainsString('│', $second);
+  }
+
+  public function testConfigIsRestoredAfterCancellation(): void {
+    $this->clearEnvVars(['dish']);
+    $before = Prompty::config();
+    $steps = self::steps();
+
+    $r = $this->promptyRun(fn(): mixed => Prompty::flow($steps, unicode: FALSE, env_prefix: 'OTHER_'), self::KEY_CTRL_C);
+
+    $this->assertNull($r['result']);
+    $this->assertSame($before['env_prefix'], Prompty::config()['env_prefix']);
+  }
+
+  public function testConfigIsRestoredAfterThrow(): void {
+    $before = Prompty::config();
+
+    $thrown = NULL;
+
+    try {
+      $this->captureOutput(function (): void {
+        Prompty::flow(function (): array {
+          throw new \RuntimeException('Kitchen closed.');
+        }, unicode: FALSE, env_prefix: 'OTHER_');
+      });
+    }
+    catch (\RuntimeException $exception) {
+      $thrown = $exception->getMessage();
+    }
+
+    $this->assertSame('Kitchen closed.', $thrown);
+    $this->assertSame($before['env_prefix'], Prompty::config()['env_prefix']);
+    $this->assertSame($before['unicode'], Prompty::config()['unicode']);
+  }
+
+  public function testGlobalConfigureStillPersists(): void {
+    Prompty::configure(env_prefix: 'KITCHEN_');
+    $this->setEnvVars(['dish' => 'plum compote'], 'KITCHEN_');
+
+    $result = NULL;
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::flow(self::steps(), unicode: FALSE);
+    });
+
+    $this->assertSame(['dish' => 'plum compote'], $result);
+    $this->assertSame('KITCHEN_', Prompty::config()['env_prefix']);
+  }
+
+}

--- a/tests/phpunit/Unit/Prompty/PromptyFlowConfigScopeTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyFlowConfigScopeTest.php
@@ -100,6 +100,13 @@ final class PromptyFlowConfigScopeTest extends PromptyTestCase {
       'symbols_unicode',
     ];
 
+    yield 'ascii symbols' => [
+      static function () use ($steps): void {
+        Prompty::flow($steps, symbols_ascii: ['bar' => '!']);
+      },
+      'symbols_ascii',
+    ];
+
     yield 'colors' => [
       static function () use ($steps): void {
         Prompty::flow($steps, colors: ['cyan' => '']);


### PR DESCRIPTION
Closes #94

## Summary

Every configuration argument `Prompty::flow()` accepts - `unicode`, `ansi`, `env_prefix`, `labels`, `truthy`, `falsy`, `colors`, `symbols_unicode`, `symbols_ascii`, `spacing` - was passed straight to `configure()`, which writes to the singleton, so a flow that asked for ASCII symbols or its own environment prefix left that setting in force for every later flow in the same process; those arguments sit right beside `intro`, `outro` and `numbering`, which are already scoped to the call, with nothing in the signature signalling the different lifetime. `env_prefix` was the sharpest case: a later flow would read a namespace it never asked for, so its prompts could silently resolve from the wrong environment variables or drop to interactive input.

`flow()` now captures the configuration with a new `configSnapshot()` before applying its own named arguments, and restores it with `configRestore()` in the `finally` block that already resets the flow state, so the prior configuration is back in force whether the flow completes, is cancelled, or throws; `configRestore()` assigns each captured value rather than merging, so a key a flow added is gone as well as one it changed. `configure()` remains the way to change something for the rest of the process.

## Changes

- Added `configSnapshot()` and `configRestore()` to `Prompty.php`; `flow()` captures the ten flow-scoped settings (`symbols_unicode`, `symbols_ascii`, `colors`, `spacing`, `labels`, `unicode`, `ansi`, `env_prefix`, `truthy`, `falsy`) before applying its own arguments and restores them in the `finally` block that already resets the flow state.
- Extracted `resolveDisplay()`, holding the two lines that derive the symbol and colour sets from the unicode and ANSI settings; `configure()` and `configRestore()` both call it instead of repeating the derivation.
- Declared the snapshot's shape once as a `@phpstan-type PromptyConfig` alias on the class docblock, so `configSnapshot()` and `configRestore()` share one type definition.
- Added `tests/phpunit/Unit/Prompty/PromptyFlowConfigScopeTest.php` (13 tests) covering every flow-scoped argument being restored after the flow that set it, a second flow seeing the global configuration rather than the first flow's overrides, restoration after the flow is cancelled and after it throws, and `Prompty::configure()` continuing to persist for the rest of the process. Run against the unpatched `Prompty.php`, 11 of the 13 fail - including `env_prefix` still reading `OTHER_` after the flow threw, and a second flow still rendering with the first flow's `....` indent - and the full suite passes with the fix applied: 565 tests, 1351 assertions.
- Documented the lifetime in the README's Configuration section: a per-flow argument lasts only as long as the flow, and `Prompty::configure()` is the way to change something for the rest of the process.
- Added `playground/flow-config-scope.php`, a runnable demo of the case: three flows - one with its own spacing, labels and environment prefix, one that asks for nothing, and one after `configure()` - with the configuration printed between them. Listed it in the contributing guide's playground table.
- Set `playground/flow-multiple.php`'s ASCII mode with `configure()` rather than on its first flow. That demo was itself depending on the leak: it passed `unicode: FALSE` to the first flow only, and its second flow rendered in ASCII because the setting carried over. Its docblock no longer claims a flow's own configuration is preserved across flows.

`playground/flow-config-scope.php` demonstrates the case end to end. It runs three flows - one that asks for its own spacing, labels and environment prefix, one that asks for nothing, and one after `configure()` - and prints the configuration between them, so the lifetime reads without comparing glyphs. Run against the code before this change, its second flow renders with the first flow's `....` indent and then stops for input, because the leaked `KITCHEN_` prefix means `PROMPTY_COURSE` no longer resolves. That is the failure the issue describes, reproduced in a script.

`playground/flow-multiple.php` was itself relying on the leak: it passed `unicode: FALSE` to its first flow only and its second flow rendered in ASCII because the setting carried over. It now sets that with `configure()`, which is what makes it global, and its docblock no longer claims a flow's own configuration is preserved across flows.

## Before / After

```
┌────────────────────────────────────────────────────────────────────┐
│ TWO CONSECUTIVE FLOWS                                              │
│                                                                    │
│   flow($steps, env_prefix: 'OTHER_', unicode: false)               │
│   flow($steps)                                                     │
│                                                                    │
│ BEFORE - flow B inherits flow A's arguments                        │
│   flow B reads OTHER_DISH instead of PROMPTY_DISH                  │
│   flow B draws ascii symbols ('|') instead of unicode ('│')        │
│   nothing undoes flow A's configure() call once it returns         │
│                                                                    │
│ AFTER - flow B sees only Prompty::configure()'s global settings    │
│   flow B reads PROMPTY_DISH, flow A's override is gone             │
│   flow B draws unicode symbols ('│'), the global default           │
│   flow A's finally block restores the snapshot on every exit path, │
│   whether it returns, is cancelled, or throws                      │
└────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Scope `Prompty::flow()` configuration to the current flow.
- Restore all affected settings after completion, cancellation, or exceptions.
- Keep `Prompty::configure()` process-wide.
- Add shared configuration typing and centralized display resolution.
- Add 13 tests for restoration, consecutive flows, cancellation, exceptions, and persistent configuration.
- Document configuration lifetime in the README.

## Possibly related

- Possibly related to `#94`.

## Testing

- Full test suite passes: 565 tests and 1,351 assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
