### PR TITLE
[#95] Rendered values and labels as printable text.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ The [`playground/`](playground) directory holds runnable demos - the quickest wa
 | `widget-placeholder.php`      | What an empty answer to a text widget means.        |
 | `widget-discovered.php`       | Where a discovered value comes from, and its forms. |
 | `widget-default.php`          | Defaults, and the option keys they are held to.     |
+| `widget-control-chars.php`    | What a control character in a value draws as.       |
 | `widgets-config.php`          | Standalone widgets with custom configuration.       |
 | `flow.php`                    | A linear flow with descriptions and hints.          |
 | `flow-nested.php`             | A nested flow with conditionals, 3 levels deep.     |

--- a/Prompty.php
+++ b/Prompty.php
@@ -623,11 +623,13 @@ class Prompty {
     $open = $ctx['open'] ?? [];
     $label = $p->numberLabel($label, $ctx);
 
+    $default = $p->printable($default);
+    $placeholder = $p->printable($placeholder);
     $resolved = $discovered ?? $ctx['discovered'] ?? NULL;
 
     if ($resolved !== NULL) {
       /** @var int|float|string|bool $resolved */
-      $display = trim((string) $resolved);
+      $display = trim($p->printable((string) $resolved));
 
       // An empty answer resolves as it does interactively: the seeded default,
       // or the placeholder when nothing was seeded.
@@ -805,7 +807,7 @@ class Prompty {
     $label = $p->numberLabel($label, $ctx);
 
     $option_keys = $p->optionKeys($options);
-    $option_labels = array_values($options);
+    $option_labels = array_map($p->printable(...), array_values($options));
     $ordered_hints = array_map(fn(string $key) => $hints[$key] ?? '', $option_keys);
 
     if ($resolved_key !== NULL) {
@@ -1006,7 +1008,7 @@ class Prompty {
     $label = $p->numberLabel($label, $ctx);
 
     $option_keys = $p->optionKeys($options);
-    $option_labels = array_values($options);
+    $option_labels = array_map($p->printable(...), array_values($options));
     $ordered_hints = array_map(fn(string $key) => $hints[$key] ?? '', $option_keys);
 
     if ($resolved_keys !== NULL) {
@@ -1320,6 +1322,26 @@ class Prompty {
   }
 
   /**
+   * Neutralises control characters that would break a rendered line.
+   *
+   * A newline or tab becomes a space, so text stays on the line the tree drew
+   * for it. Escape sequences and the remaining control bytes are removed,
+   * since a terminal acts on them rather than showing them.
+   *
+   * @param string $text
+   *   Text supplied by the caller or discovered from the environment.
+   *
+   * @return string
+   *   Text safe to compose into a rendered line.
+   */
+  protected function printable(string $text): string {
+    $text = preg_replace('/\033\[\??[0-9;]*[A-Za-z]/', '', $text) ?? $text;
+    $text = preg_replace('/[\t\n\x0b\x0c\r]+/', ' ', $text) ?? $text;
+
+    return preg_replace('/[\x00-\x1f\x7f]/', '', $text) ?? $text;
+  }
+
+  /**
    * Returns the styled vertical bar character for the tree connector.
    */
   protected function bar(): string {
@@ -1522,6 +1544,8 @@ class Prompty {
    *   The label with an optional step number suffix.
    */
   protected function numberLabel(string $label, array $ctx): string {
+    $label = $this->printable($label);
+
     if (isset($ctx['number'])) {
       /** @var string $number */
       $number = $ctx['number'];
@@ -1685,6 +1709,8 @@ class Prompty {
    *   The rendered intro lines.
    */
   protected function renderIntro(string $message): array {
+    $message = $this->printable($message);
+
     return [
       '',
       $this->color($this->cfgSymbols['intro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'bold'),
@@ -1702,6 +1728,8 @@ class Prompty {
    *   The rendered outro lines.
    */
   protected function renderOutro(string $message): array {
+    $message = $this->printable($message);
+
     return [
       $this->bar(),
       $this->color($this->cfgSymbols['outro'], 'gray') . $this->cfgSpacing['indent'] . $this->color($message, 'green'),
@@ -1726,7 +1754,7 @@ class Prompty {
     $body_prefix = $depth > 0 ? $this->bodyPrefix($depth, $open) : $this->cfgSpacing['indent'];
 
     $lines = array_map(
-      fn(string $text_line): string => $this->bar() . $body_prefix . $this->color($text_line, 'dim_italic'),
+      fn(string $text_line): string => $this->bar() . $body_prefix . $this->color($this->printable($text_line), 'dim_italic'),
       explode("\n", $description),
     );
 
@@ -1750,7 +1778,7 @@ class Prompty {
    */
   protected function renderHint(string $hint, int $depth = 0, array $open = []): array {
     $body_prefix = $depth > 0 ? $this->bodyPrefix($depth, $open) : '';
-    $hint_lines = explode("\n", $hint);
+    $hint_lines = array_map($this->printable(...), explode("\n", $hint));
 
     return array_map(
       fn(string $text_line, int $index): string => $this->bar() . $body_prefix . ($index === 0
@@ -1778,6 +1806,9 @@ class Prompty {
    *   The rendered completed-state lines.
    */
   protected function renderCompleted(string $label, string $value, int $depth = 0, array $open = []): array {
+    $label = $this->printable($label);
+    $value = $this->printable($value);
+
     if ($depth === 0) {
       return [
         $this->color($this->cfgSymbols['completed'], 'cyan') . $this->cfgSpacing['indent'] . $label,
@@ -1812,6 +1843,9 @@ class Prompty {
    *   The rendered cancelled-state lines.
    */
   protected function renderCancelled(string $label, string $value, int $depth = 0, array $open = []): array {
+    $label = $this->printable($label);
+    $value = $this->printable($value);
+
     if ($depth === 0) {
       return [
         $this->color($this->cfgSymbols['active'], 'red') . $this->cfgSpacing['indent'] . $label,

--- a/Prompty.php
+++ b/Prompty.php
@@ -1325,7 +1325,7 @@ class Prompty {
    * Neutralises control characters that would break a rendered line.
    *
    * A newline or tab becomes a space, so text stays on the line the tree drew
-   * for it. Escape sequences and the remaining control bytes are removed,
+   * for it. Escape sequences and the remaining control characters are removed,
    * since a terminal acts on them rather than showing them.
    *
    * @param string $text
@@ -1337,8 +1337,14 @@ class Prompty {
   protected function printable(string $text): string {
     $text = preg_replace('/\033\[\??[0-9;]*[A-Za-z]/', '', $text) ?? $text;
     $text = preg_replace('/[\t\n\x0b\x0c\r]+/', ' ', $text) ?? $text;
+    $text = preg_replace('/[\x00-\x1f\x7f]/', '', $text) ?? $text;
 
-    return preg_replace('/[\x00-\x1f\x7f]/', '', $text) ?? $text;
+    // The rest of the control characters are the C1 range, which UTF-8 encodes
+    // in two bytes whose second one is also a continuation byte of ordinary
+    // characters. Matching characters rather than bytes is what keeps a
+    // character such as 'ą' whole. Text that is not valid UTF-8 has no
+    // characters to match, and keeps what the passes above left it.
+    return preg_replace('/\p{Cc}/u', '', $text) ?? $text;
   }
 
   /**

--- a/Prompty.php
+++ b/Prompty.php
@@ -649,6 +649,9 @@ class Prompty {
     }
 
     $render_active = function (string $value) use ($p, $label, $placeholder, $description, $depth, $open): array {
+      // Typed bytes reach here as they were typed, and a paste can carry a
+      // control character among them.
+      $value = $p->printable($value);
       $cursor = $p->color('█', 'cyan');
       $display = $value === '' ? $p->color($placeholder, 'gray') . $cursor : $p->color($value, 'white') . $cursor;
 
@@ -690,6 +693,7 @@ class Prompty {
       }
 
       if ($key === 'enter') {
+        $value = $p->printable($value);
         $display = $value !== '' ? $value : $placeholder;
         $open = $p->settleOpen($display, $open);
         $p->redraw($line_count, $p->renderCompleted($label, $display, $depth, $open));
@@ -1012,7 +1016,7 @@ class Prompty {
     $ordered_hints = array_map(fn(string $key) => $hints[$key] ?? '', $option_keys);
 
     if ($resolved_keys !== NULL) {
-      $display = $resolved_keys !== [] ? implode(', ', array_map(fn(string $key): string => $options[$key], $resolved_keys)) : $p->cfgLabels['none'];
+      $display = $resolved_keys !== [] ? implode(', ', array_map(fn(string $key): string => $options[$key], $resolved_keys)) : $p->label('none');
       $open = $p->settleOpen($resolved_keys, $open);
       $p->printLines($p->renderCompleted($label, $display, $depth, $open));
       if ($standalone) {
@@ -1101,7 +1105,7 @@ class Prompty {
         }
 
         $open = $p->settleOpen($selected_keys, $open);
-        $p->redraw($line_count, $p->renderCompleted($label, $selected_labels !== [] ? implode(', ', $selected_labels) : $p->cfgLabels['none'], $depth, $open));
+        $p->redraw($line_count, $p->renderCompleted($label, $selected_labels !== [] ? implode(', ', $selected_labels) : $p->label('none'), $depth, $open));
         if ($standalone) {
           // @codeCoverageIgnoreStart
           $p->teardownTty();
@@ -1205,7 +1209,7 @@ class Prompty {
 
     if ($resolved_bool !== NULL) {
       $open = $p->settleOpen($resolved_bool, $open);
-      $p->printLines($p->renderCompleted($label, $resolved_bool ? $p->cfgLabels['yes'] : $p->cfgLabels['no'], $depth, $open));
+      $p->printLines($p->renderCompleted($label, $resolved_bool ? $p->label('yes') : $p->label('no'), $depth, $open));
       if ($standalone) {
         // @codeCoverageIgnoreStart
         $p->teardownTty();
@@ -1217,10 +1221,10 @@ class Prompty {
 
     $render_active = function (bool $focused_yes) use ($p, $label, $description, $depth, $open): array {
       $options_display = $focused_yes
-        ? $p->color($p->cfgSymbols['radio_on'], 'green') . ' ' . $p->cfgLabels['yes'] . ' ' . $p->color($p->cfgLabels['separator'], 'dim')
-          . ' ' . $p->color($p->cfgSymbols['radio_off'], 'dim') . ' ' . $p->color($p->cfgLabels['no'], 'dim')
-        : $p->color($p->cfgSymbols['radio_off'], 'dim') . ' ' . $p->color($p->cfgLabels['yes'], 'dim') . ' ' . $p->color($p->cfgLabels['separator'], 'dim')
-          . ' ' . $p->color($p->cfgSymbols['radio_on'], 'green') . ' ' . $p->cfgLabels['no'];
+        ? $p->color($p->cfgSymbols['radio_on'], 'green') . ' ' . $p->label('yes') . ' ' . $p->color($p->label('separator'), 'dim')
+          . ' ' . $p->color($p->cfgSymbols['radio_off'], 'dim') . ' ' . $p->color($p->label('no'), 'dim')
+        : $p->color($p->cfgSymbols['radio_off'], 'dim') . ' ' . $p->color($p->label('yes'), 'dim') . ' ' . $p->color($p->label('separator'), 'dim')
+          . ' ' . $p->color($p->cfgSymbols['radio_on'], 'green') . ' ' . $p->label('no');
 
       if ($depth === 0) {
         $lines = [$p->color($p->cfgSymbols['active'], 'cyan') . $p->cfgSpacing['indent'] . $label];
@@ -1249,7 +1253,7 @@ class Prompty {
       $key = $p->readKey();
 
       if ($p->isCancelKey($key)) {
-        $p->redraw($line_count, $p->renderCancelled($label, $yes ? $p->cfgLabels['yes'] : $p->cfgLabels['no'], $depth, $open));
+        $p->redraw($line_count, $p->renderCancelled($label, $yes ? $p->label('yes') : $p->label('no'), $depth, $open));
         if ($standalone) {
           // @codeCoverageIgnoreStart
           $p->teardownTty();
@@ -1261,7 +1265,7 @@ class Prompty {
 
       if ($key === 'enter') {
         $open = $p->settleOpen($yes, $open);
-        $p->redraw($line_count, $p->renderCompleted($label, $yes ? $p->cfgLabels['yes'] : $p->cfgLabels['no'], $depth, $open));
+        $p->redraw($line_count, $p->renderCompleted($label, $yes ? $p->label('yes') : $p->label('no'), $depth, $open));
         if ($standalone) {
           // @codeCoverageIgnoreStart
           $p->teardownTty();
@@ -1345,6 +1349,19 @@ class Prompty {
     // character such as 'ą' whole. Text that is not valid UTF-8 has no
     // characters to match, and keeps what the passes above left it.
     return preg_replace('/\p{Cc}/u', '', $text) ?? $text;
+  }
+
+  /**
+   * Returns a configured label as printable text.
+   *
+   * @param string $name
+   *   The label to read.
+   *
+   * @return string
+   *   The label, safe to compose into a rendered line.
+   */
+  protected function label(string $name): string {
+    return $this->printable($this->cfgLabels[$name] ?? '');
   }
 
   /**
@@ -1855,7 +1872,7 @@ class Prompty {
     if ($depth === 0) {
       return [
         $this->color($this->cfgSymbols['active'], 'red') . $this->cfgSpacing['indent'] . $label,
-        $this->bar() . $this->cfgSpacing['indent'] . $this->color($value, 'dim') . $this->color(' ' . $this->cfgLabels['cancelled'], 'red'),
+        $this->bar() . $this->cfgSpacing['indent'] . $this->color($value, 'dim') . $this->color(' ' . $this->label('cancelled'), 'red'),
         $this->bar(),
       ];
     }
@@ -1865,7 +1882,7 @@ class Prompty {
 
     return [
       $label_prefix . $this->color($this->cfgSymbols['active'], 'red') . $this->cfgSpacing['indent'] . $label,
-      $this->bar() . $body_prefix . $this->color($value, 'dim') . $this->color(' ' . $this->cfgLabels['cancelled'], 'red'),
+      $this->bar() . $body_prefix . $this->color($value, 'dim') . $this->color(' ' . $this->label('cancelled'), 'red'),
       $this->bar() . $body_prefix,
     ];
   }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ You may also use the [starter](#starter-script) as a template for your own scrip
 
 Four widget types cover the most common prompt patterns. Each returns the user's answer, or `null` if they cancel (Escape or Ctrl+C).
 
+Everything a widget draws is rendered as printable text. A newline or tab in a value, a label or an option label becomes a space, and escape sequences and other control characters are removed, so a value carrying them cannot break the tree or drive the terminal. `text` returns the printable form, so a caller gets the same text that was drawn.
+
 <p align="center">
   <img src=".util/assets/widgets.svg" width="100%" alt="Text, select, multiselect and confirm widgets in sequence">
 </p>

--- a/playground/widget-control-chars.php
+++ b/playground/widget-control-chars.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Playground - what a control character in a value does to the tree.
+ *
+ * A value does not always arrive clean. An environment variable populated by
+ * a command that printed more than one line carries a newline; a value pasted
+ * from somewhere else can carry a carriage return or a colour sequence. The
+ * tree is drawn line by line, so text that moves the cursor itself would draw
+ * over the tree that holds it.
+ *
+ * Every value below is drawn as printable text: escape sequences and control
+ * bytes are removed, and a newline or tab becomes a space, so the value stays
+ * on the line the tree drew for it. Each is shown with its raw bytes first,
+ * so what arrived and what was drawn can be compared.
+ *
+ * A description is split on its own newlines before any of that, so the line
+ * breaks a caller writes deliberately still render as line breaks.
+ *
+ * phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../Prompty.php';
+
+use AlexSkrypnyk\Prompty\Prompty;
+
+$opts = getopt('', ['no-unicode', 'no-ansi']);
+$unicode = !isset($opts['no-unicode']);
+$ansi = !isset($opts['no-ansi']);
+
+Prompty::configure(unicode: $unicode, ansi: $ansi);
+
+/**
+ * Show a value's raw bytes, then let a widget draw it.
+ *
+ * @param string $title
+ *   What the value carries.
+ * @param string $value
+ *   The value a widget resolves.
+ */
+function demo(string $title, string $value): void {
+  echo PHP_EOL . '--- ' . $title . ' ---' . PHP_EOL;
+  echo 'Raw bytes:   ' . json_encode($value) . PHP_EOL;
+
+  $drawn = Prompty::text('Dish name', discovered: $value);
+
+  echo 'Returned:    ' . json_encode($drawn) . PHP_EOL;
+}
+
+demo('A newline, as a multi-line command would give', "pear tart\nserves four");
+demo('A carriage return, which would draw over the line', "pear tart\rplum compote");
+demo('A tab', "pear\ttart");
+demo('An erase-line sequence', "pear tart\033[2K");
+demo('A colour sequence', "\033[31mpear tart\033[0m");
+
+echo PHP_EOL . '--- An option label carrying a newline ---' . PHP_EOL;
+Prompty::select('Course', options: ['starter' => "Star\nter", 'main' => 'Main'], discovered: 'starter');
+
+// A description is drawn while a widget is waiting, so this one asks rather
+// than resolving a value: the two lines below the label are the line breaks
+// the caller wrote, and they survive because a description is split on them
+// before anything is stripped.
+echo PHP_EOL . '--- A description keeps the line breaks it was written with ---' . PHP_EOL;
+echo 'This one waits for input. Press enter to take the placeholder.' . PHP_EOL;
+Prompty::text('Guest name',
+  placeholder: 'Jane Doe',
+  description: "Printed on the order ticket.\nLeave blank for takeaway.",
+);

--- a/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
@@ -133,6 +133,33 @@ final class PromptyControlCharactersTest extends PromptyTestCase {
     $this->assertStringContainsString('|  And on the board.', $r['output']);
   }
 
+  public function testTypedTextIsPrintable(): void {
+    // A paste delivers a character as its bytes, the same way typing does, so
+    // a control character can arrive through the input buffer.
+    $r = $this->promptyRun(fn(): mixed => Prompty::text('Dish name', ctx: $this->ctx()), "pear\u{0085}tart" . self::KEY_ENTER);
+
+    $this->assertSame('peartart', $r['result']);
+    $this->assertStringNotContainsString("\u{0085}", $r['output']);
+  }
+
+  public function testConfiguredCancelLabelIsPrintable(): void {
+    $p = $this->createAndSetInstance(['labels' => ['yes' => 'Yes', 'no' => 'No', 'cancelled' => "cancel\nled", 'none' => 'None', 'separator' => '/']]);
+
+    $lines = $this->callProtectedLines($p, 'renderCancelled', 'Dish name', 'plum compote', 0, []);
+
+    $this->assertSame('|  plum compote cancel led', $this->stripAnsi($lines[1]));
+  }
+
+  public function testConfiguredConfirmLabelsArePrintable(): void {
+    $this->createAndSetInstance(['labels' => ['yes' => "A\nye", 'no' => "N\033[2Kay", 'cancelled' => '(cancelled)', 'none' => 'None', 'separator' => '/']]);
+
+    $r = $this->promptyRun(fn(): mixed => Prompty::confirm('Send order?', ctx: $this->ctx()), self::KEY_ENTER, ['labels' => ['yes' => "A\nye", 'no' => "N\033[2Kay", 'cancelled' => '(cancelled)', 'none' => 'None', 'separator' => '/']]);
+
+    $this->assertStringContainsString('A ye', $r['output']);
+    $this->assertStringContainsString('Nay', $r['output']);
+    $this->assertStringNotContainsString("A\nye", $r['output']);
+  }
+
   public function testIntroAndOutroArePrintable(): void {
     $output = $this->captureOutput(function (): void {
       Prompty::intro("Kitchen\norder");

--- a/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for control characters in values, labels and messages.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyControlCharactersTest extends PromptyTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->createAndSetInstance();
+  }
+
+  /**
+   * Build a context array for widget execution.
+   *
+   * @param array<string, mixed> $overrides
+   *   Context overrides.
+   *
+   * @return array<string, mixed>
+   *   Context array.
+   */
+  protected function ctx(array $overrides = []): array {
+    return $this->defaultCtx(array_merge(['truthy' => ['1', 'true', 'yes'], 'falsy' => ['0', 'false', 'no']], $overrides));
+  }
+
+  #[DataProvider('dataProviderPrintable')]
+  public function testPrintable(string $text, string $expected): void {
+    $p = $this->createInstance();
+
+    $this->assertSame($expected, $this->callProtected($p, 'printable', $text));
+  }
+
+  public static function dataProviderPrintable(): \Iterator {
+    yield 'plain text' => ['plum compote', 'plum compote'];
+    yield 'newline' => ["first\nsecond", 'first second'];
+    yield 'carriage return' => ["over\rwrite", 'over write'];
+    yield 'windows newline' => ["first\r\nsecond", 'first second'];
+    yield 'tab' => ["first\tsecond", 'first second'];
+    yield 'run of newlines' => ["first\n\n\nsecond", 'first second'];
+    yield 'erase line sequence' => ["a\033[2Kb", 'ab'];
+    yield 'colour sequence' => ["\033[31mred\033[0m", 'red'];
+    yield 'lone escape' => ["a\033b", 'ab'];
+    yield 'bell' => ["a\x07b", 'ab'];
+    yield 'delete' => ["a\x7fb", 'ab'];
+    yield 'nothing to strip' => ['', ''];
+  }
+
+  public function testValueWithNewlineKeepsTheTreeIntact(): void {
+    $result = NULL;
+    $output = $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::text('Dish name', discovered: "first\nsecond", ctx: $this->ctx());
+    });
+
+    $this->assertSame('first second', $result);
+    $this->assertSame("+  Dish name\n|  first second\n|\n", $output);
+  }
+
+  #[DataProvider('dataProviderTextReturnsPrintableText')]
+  public function testTextReturnsPrintableText(string $discovered, string $expected): void {
+    $result = NULL;
+    $this->captureOutput(function () use ($discovered, &$result): void {
+      $result = Prompty::text('Dish name', discovered: $discovered, ctx: $this->ctx());
+    });
+
+    $this->assertSame($expected, $result);
+  }
+
+  public static function dataProviderTextReturnsPrintableText(): \Iterator {
+    yield 'newline' => ["first\nsecond", 'first second'];
+    yield 'carriage return' => ["over\rwrite", 'over write'];
+    yield 'erase line sequence' => ["a\033[2Kb", 'ab'];
+  }
+
+  public function testOptionLabelWithNewlineKeepsTheTreeIntact(): void {
+    $options = ['alpha' => "Al\npha", 'main' => 'Main'];
+
+    $result = NULL;
+    $output = $this->captureOutput(function () use ($options, &$result): void {
+      $result = Prompty::select('Course', options: $options, discovered: 'alpha', ctx: $this->ctx());
+    });
+
+    $this->assertSame('alpha', $result);
+    $this->assertSame("+  Course\n|  Al pha\n|\n", $output);
+  }
+
+  public function testFocusedOptionLabelIsPrintable(): void {
+    $options = ['alpha' => "Al\npha", 'main' => 'Main'];
+
+    $r = $this->promptyRun(fn(): mixed => Prompty::select('Course', options: $options, ctx: $this->ctx()), self::KEY_ENTER);
+
+    $this->assertSame('alpha', $r['result']);
+    $this->assertStringContainsString('Al pha', $r['output']);
+    $this->assertStringNotContainsString("Al\npha", $r['output']);
+  }
+
+  public function testLabelWithNewlineKeepsTheTreeIntact(): void {
+    $output = $this->captureOutput(function (): void {
+      Prompty::text("Dish\nname", discovered: 'plum compote', ctx: $this->ctx());
+    });
+
+    $this->assertSame("+  Dish name\n|  plum compote\n|\n", $output);
+  }
+
+  public function testCancelledValueIsPrintable(): void {
+    $r = $this->promptyRun(fn(): mixed => Prompty::text('Dish name', default: "first\nsecond", ctx: $this->ctx()), self::KEY_CTRL_C);
+
+    $this->assertNull($r['result']);
+    $this->assertStringContainsString('first second', $r['output']);
+  }
+
+  public function testDescriptionKeepsItsOwnLineBreaks(): void {
+    // A description renders while the widget is active, so this drives it with
+    // keystrokes rather than resolving it from a discovered value.
+    $r = $this->promptyRun(fn(): mixed => Prompty::text('Dish name', description: "Written on the ticket.\nAnd on the board.", ctx: $this->ctx()), 'plum compote' . self::KEY_ENTER);
+
+    $this->assertStringContainsString('|  Written on the ticket.', $r['output']);
+    $this->assertStringContainsString('|  And on the board.', $r['output']);
+  }
+
+  public function testIntroAndOutroArePrintable(): void {
+    $output = $this->captureOutput(function (): void {
+      Prompty::intro("Kitchen\norder");
+      Prompty::outro("Order\nsent");
+    });
+
+    $this->assertStringContainsString('Kitchen order', $output);
+    $this->assertStringContainsString('Order sent', $output);
+  }
+
+}

--- a/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php
@@ -53,6 +53,11 @@ final class PromptyControlCharactersTest extends PromptyTestCase {
     yield 'lone escape' => ["a\033b", 'ab'];
     yield 'bell' => ["a\x07b", 'ab'];
     yield 'delete' => ["a\x7fb", 'ab'];
+    yield 'c1 sequence introducer' => ["pear\u{009B}2Ktart", 'pear2Ktart'];
+    yield 'c1 next line' => ["pear\u{0085}tart", 'peartart'];
+    yield 'multibyte character holding a c1 byte' => ["pi\u{0105}tek", "pi\u{0105}tek"];
+    yield 'multibyte character holding a csi byte' => ["\u{069B}tart", "\u{069B}tart"];
+    yield 'text that is not valid utf8' => ["pear\xC3\x28tart\x07", "pear\xC3\x28tart"];
     yield 'nothing to strip' => ['', ''];
   }
 


### PR DESCRIPTION
Closes #95

## Summary

Values and labels were drawn exactly as they arrived. A newline in a discovered value emitted its continuation line with no tree prefix, breaking the tree; carriage returns and escape sequences reached the terminal intact, where a `\r` redraws over the line and `ESC[2K` erases it; and `text()` handed the raw bytes back to the caller. A new `printable()` neutralises text where it is composed into a rendered line: escape sequences and control characters are removed, and a newline or tab becomes a space, so the text stays on the line the tree drew for it.

## Changes

- Added `printable()` to `Prompty.php` and applied it at `numberLabel()` - the single label choke point shared by all four widgets - to the option label lists in `select()` and `multiselect()`, in `renderCompleted()`, `renderCancelled()`, `renderIntro()` and `renderOutro()`, and per line in `renderDescription()` and `renderHint()` after they split on their own newlines, so a line break a caller writes deliberately still renders as a line break.
- Made a discovered value printable as it is resolved in `text()`, so a widget returns the same text it drew rather than the raw bytes.
- Matched the C1 control range (U+0080-U+009F) as characters with `\p{Cc}` rather than as bytes: those characters are two bytes in UTF-8 and the second byte doubles as a continuation byte of ordinary characters, so matching a byte at a time would cut a character such as `ą` (U+0105, bytes `C4 85`) apart. Text that is not valid UTF-8 keeps what the earlier byte-level passes left it, rather than being returned unsanitised.
- Left `Prompty::output()` unsanitised - it is the escape hatch for a caller printing their own composed lines, which may legitimately carry colour.
- Added `tests/phpunit/Unit/Prompty/PromptyControlCharactersTest.php` (27 tests) covering the `printable()` transformation table, whole rendered blocks for a value and an option label carrying a newline, the value `text()` returns being printable, C1 characters, multibyte characters surviving, invalid UTF-8, and a description keeping its own line breaks. Run against `Prompty.php` before this change, the new tests give 12 errors and 9 failures.
- Added `playground/widget-control-chars.php`, a runnable demo of the case: each value is shown as raw bytes, drawn by a widget, then printed as returned. Listed it in the contributing guide's playground table.
- Documented in the README's Widgets section that everything a widget draws is rendered as printable text.
- Re-recorded the SVGs under `.util/assets/`; they came back byte-identical, confirming the change does not alter what any existing demo draws.

Two paths that the first pass missed are covered as well. Bytes below 32 are rejected as they are typed, but a C1 character arrives as two ordinary bytes, so a paste carrying one reached both the drawn line and the value `text()` returned; the typed buffer is now made printable where it is drawn and where it is returned. And a configured label is caller-supplied text composed straight into a line, so a newline in `cancelled` broke the tree and an escape sequence in `yes` reached the terminal; labels are now read through a `label()` helper that returns them printable, and no site composes `cfgLabels` directly.

## Before / After

Rendered tree for a discovered value carrying a newline (`"first\nsecond"`), with `ansi: FALSE` so the escape codes are not shown:

```
┌────────────────────┬────────────────────┐
│ BEFORE             │ AFTER              │
├────────────────────┼────────────────────┤
│ +  Dish name       │ +  Dish name       │
│ |  first           │ |  first second    │
│ second             │ |                  │
│ |                  │                    │
└────────────────────┴────────────────────┘
```

Before the fix, the embedded newline breaks out of the tree - `second` is written flush left with no `|` prefix - and `text()` returns `"first\nsecond"` unchanged. After the fix the value collapses onto the line the tree drew for it, and `text()` returns `first second`, the same text that was rendered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add `printable()` to remove control characters and ANSI escape sequences.
- Convert newlines and tabs to spaces in rendered values and labels.
- Preserve intentional line breaks in descriptions and hints.
- Sanitize widget output, option labels, messages, and discovered values.
- Update `text()` to return the sanitized rendered value.
- Keep `Prompty::output()` unsanitized.
- Add 27 unit tests for control characters and rendering behavior.
- Add a control-character playground demo.
- Update the README and contributing guide.
- Re-record SVG assets.

## Possibly related

- Possibly related to `#95`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
