### PR TITLE
[#96] Rejected configuration keys outside the set each argument declares.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ The [`playground/`](playground) directory holds runnable demos - the quickest wa
 | `widget-discovered.php`       | Where a discovered value comes from, and its forms. |
 | `widget-default.php`          | Defaults, and the option keys they are held to.     |
 | `widgets-config.php`          | Standalone widgets with custom configuration.       |
+| `widgets-config-keys.php`     | What `configure()` accepts, and what it turns down. |
 | `flow.php`                    | A linear flow with descriptions and hints.          |
 | `flow-nested.php`             | A nested flow with conditionals, 3 levels deep.     |
 | `flow-config.php`             | A flow with `configure()` applied beforehand.       |

--- a/Prompty.php
+++ b/Prompty.php
@@ -385,19 +385,24 @@ class Prompty {
   ): void {
     $p = static::instance();
     if ($symbols_unicode !== NULL) {
+      $p->assertConfigKeys('symbols_unicode', $symbols_unicode, $p->cfgSymbolsUnicode);
       $p->cfgSymbolsUnicode = array_replace($p->cfgSymbolsUnicode, $symbols_unicode);
     }
     if ($symbols_ascii !== NULL) {
+      $p->assertConfigKeys('symbols_ascii', $symbols_ascii, $p->cfgSymbolsAscii);
       $p->cfgSymbolsAscii = array_replace($p->cfgSymbolsAscii, $symbols_ascii);
     }
     if ($colors !== NULL) {
+      $p->assertConfigKeys('colors', $colors, $p->cfgColorsDefault);
       $p->cfgColorsDefault = array_replace($p->cfgColorsDefault, $colors);
       $p->cfgColors = array_replace($p->cfgColors, $colors);
     }
     if ($spacing !== NULL) {
+      $p->assertConfigKeys('spacing', $spacing, $p->cfgSpacing);
       $p->cfgSpacing = array_replace($p->cfgSpacing, $spacing);
     }
     if ($labels !== NULL) {
+      $p->assertConfigKeys('labels', $labels, $p->cfgLabels);
       $p->cfgLabels = array_replace($p->cfgLabels, $labels);
     }
     if ($unicode !== NULL) {
@@ -410,9 +415,11 @@ class Prompty {
       $p->cfgEnvPrefix = $env_prefix;
     }
     if ($truthy !== NULL) {
+      $p->assertConfigList('truthy', $truthy);
       $p->cfgTruthy = $truthy;
     }
     if ($falsy !== NULL) {
+      $p->assertConfigList('falsy', $falsy);
       $p->cfgFalsy = $falsy;
     }
     $p->resolveDisplay();
@@ -716,6 +723,44 @@ class Prompty {
       }
 
       $line_count = $p->redraw($line_count, $render_active($value));
+    }
+  }
+
+  /**
+   * Rejects configuration keys outside the set the default declares.
+   *
+   * @param string $parameter
+   *   The configure() parameter that supplied the values.
+   * @param array<string, string> $values
+   *   The supplied overrides.
+   * @param array<string, string> $declared
+   *   The defaults, whose keys are the valid set.
+   *
+   * @throws \InvalidArgumentException
+   *   When a key is not part of the declared set.
+   */
+  protected function assertConfigKeys(string $parameter, array $values, array $declared): void {
+    foreach (array_keys($values) as $key) {
+      if (!array_key_exists($key, $declared)) {
+        throw new \InvalidArgumentException(sprintf('Configuration key "%s" for "%s" is not valid. Available keys: %s.', $key, $parameter, implode(', ', array_keys($declared))));
+      }
+    }
+  }
+
+  /**
+   * Rejects a configuration list that holds nothing.
+   *
+   * @param string $parameter
+   *   The configure() parameter that supplied the values.
+   * @param list<string> $values
+   *   The supplied values.
+   *
+   * @throws \InvalidArgumentException
+   *   When the list is empty.
+   */
+  protected function assertConfigList(string $parameter, array $values): void {
+    if ($values === []) {
+      throw new \InvalidArgumentException(sprintf('No values declared for "%s". Provide at least one value.', $parameter));
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ $results = Prompty::flow(fn(): array => [/* ... */],
 
 ### Unknown keys are rejected
 
-`labels`, `spacing`, `colors`, `symbols_unicode` and `symbols_ascii` each accept a fixed set of keys, listed above. A key outside that set is rejected rather than merged in, so a misspelling fails at the call instead of quietly doing nothing:
+`labels`, `spacing`, `colors`, `symbols_unicode` and `symbols_ascii` each accept a fixed set of keys - whichever ones the defaults declare, which `Prompty::config()` prints. A key outside that set is rejected rather than merged in, so a misspelling fails at the call instead of quietly doing nothing, and the message lists the keys that would have worked:
 
 ```text
 Configuration key "bogus" for "labels" is not valid. Available keys: yes, no, cancelled, none, separator.
@@ -618,6 +618,7 @@ Configuration key "bogus" for "labels" is not valid. Available keys: yes, no, ca
 `truthy` and `falsy` must each list at least one value, since a `confirm` widget that cannot resolve half its domain would reject every value it was given.
 
 An empty `env_prefix` is accepted, and makes discovery read the bare uppercased step key. A step named `path`, `home` or `user` then reads `PATH`, `HOME` or `USER` from the ambient environment, so keep a prefix unless you mean exactly that.
+
 ### Other methods
 
 Besides the four widgets and `flow()`, the class exposes:

--- a/README.md
+++ b/README.md
@@ -607,6 +607,17 @@ $results = Prompty::flow(fn(): array => [/* ... */],
 | `colors`          | `array<string, string>` | ANSI color escape overrides                              |
 | `spacing`         | `array<string, string>` | Indentation strings                                      |
 
+### Unknown keys are rejected
+
+`labels`, `spacing`, `colors`, `symbols_unicode` and `symbols_ascii` each accept a fixed set of keys, listed above. A key outside that set is rejected rather than merged in, so a misspelling fails at the call instead of quietly doing nothing:
+
+```text
+Configuration key "bogus" for "labels" is not valid. Available keys: yes, no, cancelled, none, separator.
+```
+
+`truthy` and `falsy` must each list at least one value, since a `confirm` widget that cannot resolve half its domain would reject every value it was given.
+
+An empty `env_prefix` is accepted, and makes discovery read the bare uppercased step key. A step named `path`, `home` or `user` then reads `PATH`, `HOME` or `USER` from the ambient environment, so keep a prefix unless you mean exactly that.
 ### Other methods
 
 Besides the four widgets and `flow()`, the class exposes:

--- a/playground/widgets-config-keys.php
+++ b/playground/widgets-config-keys.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @file
+ * Playground - what configure() accepts, and what it turns down.
+ *
+ * The symbol, colour, label and spacing arguments each take a fixed set of
+ * keys. A key outside that set used to be merged in and then never read, so a
+ * misspelling changed nothing and said nothing. It is rejected now, and the
+ * message names the key and lists the ones that would have worked.
+ *
+ * Each call below is made for real: the ones that are turned down print the
+ * message they were turned down with, and the one that is accepted then shows
+ * the symbol it changed.
+ *
+ * phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../Prompty.php';
+
+use AlexSkrypnyk\Prompty\Prompty;
+
+/**
+ * Make a configure() call and report what it did.
+ *
+ * @param string $title
+ *   What the call is trying to do.
+ * @param callable $call
+ *   The configure() call.
+ */
+function attempt(string $title, callable $call): void {
+  echo PHP_EOL . '--- ' . $title . ' ---' . PHP_EOL;
+
+  try {
+    $call();
+    echo 'Accepted.' . PHP_EOL;
+  }
+  catch (\InvalidArgumentException $exception) {
+    echo 'Turned down: ' . $exception->getMessage() . PHP_EOL;
+  }
+}
+
+attempt('A label key that does not exist', function (): void {
+  Prompty::configure(labels: ['bogus' => 'X']);
+});
+
+attempt('A real label key, spelled with a stray space', function (): void {
+  Prompty::configure(labels: ['yes ' => 'Aye']);
+});
+
+attempt('A symbol key that does not exist', function (): void {
+  Prompty::configure(symbols_unicode: ['bogus' => 'X']);
+});
+
+attempt('A spacing key that does not exist', function (): void {
+  Prompty::configure(spacing: ['padding' => '  ']);
+});
+
+attempt('A colour key that does not exist', function (): void {
+  Prompty::configure(colors: ['turquoise' => "\033[36m"]);
+});
+
+attempt('An empty truthy list, which confirm() could never match', function (): void {
+  Prompty::configure(truthy: []);
+});
+
+attempt('A label key that does exist', function (): void {
+  Prompty::configure(labels: ['yes' => 'Aye', 'no' => 'Nay']);
+});
+
+echo PHP_EOL . 'The accepted call changed what a confirm widget draws:' . PHP_EOL;
+Prompty::confirm('Send order?', discovered: TRUE);
+
+echo PHP_EOL . '--- An empty env_prefix is accepted ---' . PHP_EOL;
+echo 'It is a coherent thing to ask for, so it is allowed, but a step named' . PHP_EOL;
+echo 'path, home or user then reads PATH, HOME or USER from the environment' . PHP_EOL;
+echo 'the script was started with. Keep a prefix unless that is the intent.' . PHP_EOL;

--- a/tests/phpunit/Unit/Prompty/PromptyConfigureKeysTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyConfigureKeysTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for the keys and lists configure() accepts.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyConfigureKeysTest extends PromptyTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->createAndSetInstance();
+  }
+
+  /**
+   * The message an unknown key produces.
+   *
+   * @param string $parameter
+   *   The configure() parameter that carried the key.
+   * @param string $config_key
+   *   The config() key holding the valid set.
+   *
+   * @return string
+   *   The expected exception message.
+   */
+  protected function rejection(string $parameter, string $config_key): string {
+    /** @var array<string, string> $declared */
+    $declared = Prompty::config()[$config_key];
+
+    return sprintf('Configuration key "bogus" for "%s" is not valid. Available keys: %s.', $parameter, implode(', ', array_keys($declared)));
+  }
+
+  #[DataProvider('dataProviderRejectsUnknownKey')]
+  public function testRejectsUnknownKey(\Closure $configure, string $parameter, string $config_key): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage($this->rejection($parameter, $config_key));
+
+    $configure();
+  }
+
+  public static function dataProviderRejectsUnknownKey(): \Iterator {
+    yield 'unicode symbols' => [
+      static function (): void {
+        Prompty::configure(symbols_unicode: ['bogus' => 'X']);
+      },
+      'symbols_unicode',
+      'symbols_unicode',
+    ];
+
+    yield 'ascii symbols' => [
+      static function (): void {
+        Prompty::configure(symbols_ascii: ['bogus' => 'X']);
+      },
+      'symbols_ascii',
+      'symbols_ascii',
+    ];
+
+    yield 'colors' => [
+      static function (): void {
+        Prompty::configure(colors: ['bogus' => 'X']);
+      },
+      'colors',
+      'colors',
+    ];
+
+    yield 'spacing' => [
+      static function (): void {
+        Prompty::configure(spacing: ['bogus' => 'X']);
+      },
+      'spacing',
+      'spacing',
+    ];
+
+    yield 'labels' => [
+      static function (): void {
+        Prompty::configure(labels: ['bogus' => 'X']);
+      },
+      'labels',
+      'labels',
+    ];
+  }
+
+  public function testRejectsMisspeltKey(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Configuration key "bar_" for "symbols_unicode" is not valid.');
+
+    Prompty::configure(symbols_unicode: ['bar_' => '|']);
+  }
+
+  #[DataProvider('dataProviderRejectsEmptyList')]
+  public function testRejectsEmptyList(\Closure $configure, string $parameter): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage(sprintf('No values declared for "%s". Provide at least one value.', $parameter));
+
+    $configure();
+  }
+
+  public static function dataProviderRejectsEmptyList(): \Iterator {
+    yield 'truthy' => [
+      static function (): void {
+        Prompty::configure(truthy: []);
+      },
+      'truthy',
+    ];
+
+    yield 'falsy' => [
+      static function (): void {
+        Prompty::configure(falsy: []);
+      },
+      'falsy',
+    ];
+  }
+
+  public function testAcceptsDeclaredKeys(): void {
+    Prompty::configure(symbols_ascii: ['bar' => '!'], spacing: ['indent' => '    '], labels: ['yes' => 'Aye']);
+
+    $config = Prompty::config();
+
+    $this->assertIsArray($config['labels']);
+    $this->assertIsArray($config['spacing']);
+    $this->assertIsArray($config['symbols_ascii']);
+
+    $this->assertSame('Aye', $config['labels']['yes']);
+    $this->assertSame('    ', $config['spacing']['indent']);
+    $this->assertSame('!', $config['symbols_ascii']['bar']);
+  }
+
+  public function testRejectionLeavesTheConfigurationAlone(): void {
+    $before = Prompty::config();
+
+    try {
+      Prompty::configure(labels: ['yes' => 'Aye', 'bogus' => 'X']);
+    }
+    catch (\InvalidArgumentException) {
+      // The message is asserted elsewhere; this checks nothing was applied.
+    }
+
+    $this->assertSame($before['labels'], Prompty::config()['labels']);
+  }
+
+}


### PR DESCRIPTION
Closes #96

## Summary

`Prompty::configure()` merged each array argument over its defaults with `array_replace()`, so a key outside the set the defaults declare was added rather than rejected. A misspelled symbol, colour, label or spacing key was accepted silently, had no effect on rendering, and then appeared in `config()` as though it were real - the failure only surfaced by noticing that a symbol you tried to change did not change. `configure()` now checks each array argument against the keys its own default declares, and rejects an empty `truthy` or `falsy` list, since `confirm()` could never match a value against it.

## Changes

- Added `assertConfigKeys()` to `Prompty.php`, checking each of `symbols_unicode`, `symbols_ascii`, `colors`, `spacing` and `labels` against `array_keys()` of its own default before merging, and throwing an `InvalidArgumentException` that names the offending key and lists the ones that would have worked - the same shape `assertOptionKey()` already uses for widget options, so there is no second list of valid keys to maintain.
- Added `assertConfigList()`, rejecting an empty `truthy` or `falsy` list with the same message shape `assertDeclaredOptions()` already uses for an empty options map.
- Left an empty `env_prefix` accepted: reading unprefixed environment names is a coherent thing to ask for, so the README documents it rather than rejecting it, including that a step named `path`, `home` or `user` then reads `PATH`, `HOME` or `USER` from the ambient environment.
- Added `tests/phpunit/Unit/Prompty/PromptyConfigureKeysTest.php` (10 tests): one unknown-key case per array argument, a real key misspelled with a stray character, an empty `truthy` list, an empty `falsy` list, declared keys still applying, and a rejection leaving the configuration untouched. Run against the code before this change, 9 of the 10 fail.
- Added `playground/widgets-config-keys.php`, making each call for real and printing the message it was turned down with, then showing the accepted call changing what a `confirm()` widget draws; listed in the contributing guide's playground table. Run against the code before this change, it prints `Accepted.` for every misspelling.
- Documented the rejection under a new "Unknown keys are rejected" section in the README's Configuration section, including the `env_prefix` decision above.

## Before / After

```
┌──────────────────────────────────────────────────────────────────────┐
│ Prompty::configure(labels: ['bogus' => 'X'])                         │
│                                                                        │
│ BEFORE                                                                │
│   array_replace() merges 'bogus' into cfgLabels                      │
│   config()['labels'] now contains 'bogus' => 'X'                     │
│   no widget reads that key, so nothing ever renders differently      │
│   the call returns silently - no error, no signal anything is wrong  │
│                                                                        │
│ AFTER                                                                 │
│   assertConfigKeys() checks 'bogus' against array_keys(cfgLabels)    │
│   the key is not declared, so an InvalidArgumentException is thrown  │
│   cfgLabels is left exactly as it was before the call                │
│   message: Configuration key "bogus" for "labels" is not valid.      │
│            Available keys: yes, no, cancelled, none, separator.      │
└──────────────────────────────────────────────────────────────────────┘
```
