### PR TITLE
[#97] Rejected step keys that cannot be written as an environment variable name.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ The [`playground/`](playground) directory holds runnable demos - the quickest wa
 | `flow-config.php`             | A flow with `configure()` applied beforehand.       |
 | `flow-multiple.php`           | Several flows, and a standalone widget between them.|
 | `flow-config-scope.php`       | How long a flow's own configuration lasts.          |
+| `flow-step-keys.php`          | What a step key becomes, and which are turned down. |
 | `flow-embed.php`              | The flow the embedder is tested against.            |
 
 ```bash

--- a/Prompty.php
+++ b/Prompty.php
@@ -1637,18 +1637,31 @@ class Prompty {
   }
 
   /**
-   * Rejects step keys that cannot be written as an environment variable name.
+   * Rejects steps whose environment variable name cannot be exported.
+   *
+   * A step is looked up as its key uppercased behind the prefix. A name that
+   * is not a shell identifier can still be set by a parent process, but it
+   * cannot be exported from a shell or written in most .env files, so a step
+   * named that way could never be filled by the means callers actually use.
    *
    * @param array<array-key, mixed> $steps
    *   Flow steps, keyed by step name.
    *
    * @throws \InvalidArgumentException
-   *   When a key holds a character outside letters, digits and underscores.
+   *   When the name a step resolves through is not a valid variable name.
    */
   protected function assertStepKeys(array $steps): void {
     foreach ($steps as $key => $step) {
-      if (preg_match('/^[A-Za-z0-9_]+$/', (string) $key) !== 1) {
-        throw new \InvalidArgumentException(sprintf('Step key "%s" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.', $key));
+      if ((string) $key === '') {
+        throw new \InvalidArgumentException('A step must have a key: it names the answer in the results and the variable the answer can come from.');
+      }
+
+      $name = $this->cfgEnvPrefix . strtoupper((string) $key);
+
+      // The name is checked rather than the key, so a prefix that cannot be
+      // exported is caught as well as a key that cannot.
+      if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) !== 1) {
+        throw new \InvalidArgumentException(sprintf('Step "%s" is looked up as the environment variable "%s", which cannot be exported. A variable name may hold only letters, digits and underscores, and may not start with a digit.', $key, $name));
       }
 
       $children = is_array($step) ? $step['__children'] ?? NULL : NULL;

--- a/Prompty.php
+++ b/Prompty.php
@@ -501,6 +501,7 @@ class Prompty {
 
     try {
       $steps = $steps();
+      $p->assertStepKeys($steps);
 
       $options = [
         'numbering' => $numbering,
@@ -1633,6 +1634,29 @@ class Prompty {
     }
 
     return array_values(array_filter($this->optionKeys($options), fn(string $key): bool => in_array($key, $selected, TRUE)));
+  }
+
+  /**
+   * Rejects step keys that cannot be written as an environment variable name.
+   *
+   * @param array<array-key, mixed> $steps
+   *   Flow steps, keyed by step name.
+   *
+   * @throws \InvalidArgumentException
+   *   When a key holds a character outside letters, digits and underscores.
+   */
+  protected function assertStepKeys(array $steps): void {
+    foreach ($steps as $key => $step) {
+      if (preg_match('/^[A-Za-z0-9_]+$/', (string) $key) !== 1) {
+        throw new \InvalidArgumentException(sprintf('Step key "%s" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.', $key));
+      }
+
+      $children = is_array($step) ? $step['__children'] ?? NULL : NULL;
+
+      if (is_array($children)) {
+        $this->assertStepKeys($children);
+      }
+    }
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -400,11 +400,13 @@ The list form takes each entry literally, which is the way to select an option k
 
 For confirm widgets, env values are interpreted using configurable truthy/falsy lists (default: `1`/`true`/`yes` and `0`/`false`/`no`).
 
-Step keys become part of the variable name, so they may hold only letters, digits and underscores. `ci_provider` reads `PROMPTY_CI_PROVIDER`, which any shell can export; `ci-provider` would read `PROMPTY_CI-PROVIDER`, which is not a valid shell identifier and so could never be set with `export` or written in most `.env` files. A key holding anything else is rejected when the flow starts, rather than quietly never resolving:
+A step is looked up as its key uppercased behind the prefix, so `ci_provider` reads `PROMPTY_CI_PROVIDER`. A name outside letters, digits and underscores can still be set by a parent process - `env 'PROMPTY_CI-PROVIDER=x' php your-script.php` works - but it is not a shell identifier, so `export PROMPTY_CI-PROVIDER=x` is a syntax error in bash, zsh and sh, and most `.env` parsers will not accept it. A step named that way could never be filled by the means callers actually reach for, so it is turned down when the flow starts rather than quietly never resolving:
 
 ```text
-Step key "ci-provider" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.
+Step "ci-provider" is looked up as the environment variable "PROMPTY_CI-PROVIDER", which cannot be exported. A variable name may hold only letters, digits and underscores, and may not start with a digit.
 ```
+
+The name is what is checked, not the key alone, so an `env_prefix` that cannot be exported is caught the same way - and with an empty prefix, a key starting with a digit is too, since a name cannot.
 
 ### Discovered and default values must be valid answers
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ The list form takes each entry literally, which is the way to select an option k
 
 For confirm widgets, env values are interpreted using configurable truthy/falsy lists (default: `1`/`true`/`yes` and `0`/`false`/`no`).
 
+Step keys become part of the variable name, so they may hold only letters, digits and underscores. `ci_provider` reads `PROMPTY_CI_PROVIDER`, which any shell can export; `ci-provider` would read `PROMPTY_CI-PROVIDER`, which is not a valid shell identifier and so could never be set with `export` or written in most `.env` files. A key holding anything else is rejected when the flow starts, rather than quietly never resolving:
+
+```text
+Step key "ci-provider" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.
+```
+
 ### Discovered and default values must be valid answers
 
 A discovered value has to be an answer the widget would have accepted interactively. For `select` and `multiselect` that means a key of `options`; for `confirm`, a value in the truthy or falsy list. Anything else throws an `InvalidArgumentException` naming the widget, the offending value, and what was allowed:

--- a/playground/flow-step-keys.php
+++ b/playground/flow-step-keys.php
@@ -7,11 +7,13 @@
  * A step's key is uppercased behind the prefix to make the name discovery
  * reads, so a step keyed 'dish_name' is pre-filled by PROMPTY_DISH_NAME.
  *
- * A key holding anything but letters, digits and underscores makes a name a
- * shell cannot export: 'ci-provider' becomes PROMPTY_CI-PROVIDER, which
- * 'export' rejects as a syntax error and most .env parsers will not accept.
- * Such a step could never be pre-filled - the lookup found nothing and the
- * flow prompted instead, saying nothing about why. It is turned down now.
+ * A name outside letters, digits and underscores can still be set by a parent
+ * process - env 'PROMPTY_CI-PROVIDER=x' php script.php works - but 'export'
+ * rejects it as a syntax error and most .env parsers will not accept it. A
+ * step named that way could never be filled by the means callers reach for:
+ * the lookup found nothing and the flow prompted instead, saying nothing
+ * about why. It is turned down now, and the name is what is checked, so a
+ * prefix that cannot be exported is caught the same way.
  *
  * The first flow is turned down and prints the message. The second is
  * accepted, and its answers come from the environment.

--- a/playground/flow-step-keys.php
+++ b/playground/flow-step-keys.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Playground - what a step key becomes, and which ones are turned down.
+ *
+ * A step's key is uppercased behind the prefix to make the name discovery
+ * reads, so a step keyed 'dish_name' is pre-filled by PROMPTY_DISH_NAME.
+ *
+ * A key holding anything but letters, digits and underscores makes a name a
+ * shell cannot export: 'ci-provider' becomes PROMPTY_CI-PROVIDER, which
+ * 'export' rejects as a syntax error and most .env parsers will not accept.
+ * Such a step could never be pre-filled - the lookup found nothing and the
+ * flow prompted instead, saying nothing about why. It is turned down now.
+ *
+ * The first flow is turned down and prints the message. The second is
+ * accepted, and its answers come from the environment.
+ *
+ * phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../Prompty.php';
+
+use AlexSkrypnyk\Prompty\Prompty;
+
+echo '--- A key a shell cannot export ---' . PHP_EOL;
+echo 'Trying a flow with a step keyed "ci-provider".' . PHP_EOL;
+
+try {
+  Prompty::flow(fn(): array => [
+    'ci-provider' => Prompty::text('Provider'),
+  ]);
+  echo 'Accepted.' . PHP_EOL;
+}
+catch (\InvalidArgumentException $exception) {
+  echo 'Turned down: ' . $exception->getMessage() . PHP_EOL;
+}
+
+echo PHP_EOL . '--- The same key inside children ---' . PHP_EOL;
+
+try {
+  Prompty::flow(fn(): array => [
+    'course' => Prompty::confirm('Send order?', discovered: TRUE, children: [
+      'side.dish' => Prompty::text('Side dish'),
+    ]),
+  ]);
+  echo 'Accepted.' . PHP_EOL;
+}
+catch (\InvalidArgumentException $exception) {
+  echo 'Turned down: ' . $exception->getMessage() . PHP_EOL;
+}
+
+echo PHP_EOL . '--- Keys that are fine ---' . PHP_EOL;
+echo 'dish_name reads PROMPTY_DISH_NAME, dishName reads PROMPTY_DISHNAME,' . PHP_EOL;
+echo 'and course2 reads PROMPTY_COURSE2. Set those three to see them' . PHP_EOL;
+echo 'pre-filled; leave them unset and the flow asks instead.' . PHP_EOL . PHP_EOL;
+
+$results = Prompty::flow(fn(): array => [
+  'dish_name' => Prompty::text('Dish name', placeholder: 'pear tart'),
+  'dishName' => Prompty::text('Written as', placeholder: 'on the ticket'),
+  'course2' => Prompty::select('Second course', options: ['starter' => 'Starter', 'main' => 'Main']),
+],
+  intro: 'Keys that can be exported',
+  outro: 'Order noted.',
+  cancelled: 'Cancelled.',
+);
+
+if ($results === NULL) {
+  exit(0);
+}
+
+echo PHP_EOL . 'Collected:' . PHP_EOL;
+
+foreach ($results as $key => $value) {
+  echo '  ' . $key . ': ' . (is_string($value) ? $value : json_encode($value)) . PHP_EOL;
+}

--- a/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\Prompty\Tests\Unit\Prompty;
+
+use AlexSkrypnyk\Prompty\Prompty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for step keys, which are uppercased into variable names.
+ */
+#[CoversClass(Prompty::class)]
+#[Group('unit')]
+final class PromptyStepKeyTest extends PromptyTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->createAndSetInstance();
+  }
+
+  /**
+   * The message a rejected key produces.
+   *
+   * @param string $key
+   *   The offending key.
+   *
+   * @return string
+   *   The expected exception message.
+   */
+  protected function rejection(string $key): string {
+    return sprintf('Step key "%s" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.', $key);
+  }
+
+  #[DataProvider('dataProviderRejectsKey')]
+  public function testRejectsKey(string $key): void {
+    $output = $this->captureOutputThrows(\InvalidArgumentException::class, $this->rejection($key), function () use ($key): void {
+      Prompty::flow(fn(): array => [$key => Prompty::text('Dish name', discovered: 'plum compote')], unicode: FALSE);
+    });
+
+    $this->assertSame('', $output);
+  }
+
+  public static function dataProviderRejectsKey(): \Iterator {
+    yield 'hyphen' => ['ci-provider'];
+    yield 'dot' => ['ci.provider'];
+    yield 'space' => ['ci provider'];
+    yield 'bracket' => ['ci[provider]'];
+    yield 'empty' => [''];
+  }
+
+  public function testRejectsChildKey(): void {
+    $this->captureOutputThrows(\InvalidArgumentException::class, $this->rejection('with-dash'), function (): void {
+      Prompty::flow(fn(): array => [
+        'course' => Prompty::confirm('Send order?', discovered: TRUE, children: [
+          'with-dash' => Prompty::text('Dish name', discovered: 'plum compote'),
+        ]),
+      ], unicode: FALSE);
+    });
+  }
+
+  #[DataProvider('dataProviderAcceptsKey')]
+  public function testAcceptsKey(string $key): void {
+    $this->setEnvVars([$key => 'plum compote']);
+
+    $result = NULL;
+    $this->captureOutput(function () use ($key, &$result): void {
+      $result = Prompty::flow(fn(): array => [$key => Prompty::text('Dish name')], unicode: FALSE);
+    });
+
+    $this->assertSame([$key => 'plum compote'], $result);
+  }
+
+  public static function dataProviderAcceptsKey(): \Iterator {
+    yield 'lowercase' => ['dish'];
+    yield 'underscored' => ['dish_name'];
+    yield 'mixed case' => ['dishName'];
+    yield 'trailing digit' => ['dish2'];
+  }
+
+}

--- a/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
@@ -22,16 +22,18 @@ final class PromptyStepKeyTest extends PromptyTestCase {
   }
 
   /**
-   * The message a rejected key produces.
+   * The message a rejected step produces.
    *
    * @param string $key
    *   The offending key.
+   * @param string $prefix
+   *   The environment prefix in force.
    *
    * @return string
    *   The expected exception message.
    */
-  protected function rejection(string $key): string {
-    return sprintf('Step key "%s" is not valid. A step key is uppercased into an environment variable name, so it may hold only letters, digits and underscores.', $key);
+  protected function rejection(string $key, string $prefix = 'PROMPTY_'): string {
+    return sprintf('Step "%s" is looked up as the environment variable "%s", which cannot be exported. A variable name may hold only letters, digits and underscores, and may not start with a digit.', $key, $prefix . strtoupper($key));
   }
 
   #[DataProvider('dataProviderRejectsKey')]
@@ -48,7 +50,12 @@ final class PromptyStepKeyTest extends PromptyTestCase {
     yield 'dot' => ['ci.provider'];
     yield 'space' => ['ci provider'];
     yield 'bracket' => ['ci[provider]'];
-    yield 'empty' => [''];
+  }
+
+  public function testRejectsEmptyKey(): void {
+    $this->captureOutputThrows(\InvalidArgumentException::class, 'A step must have a key: it names the answer in the results and the variable the answer can come from.', function (): void {
+      Prompty::flow(fn(): array => ['' => Prompty::text('Dish name', discovered: 'plum compote')], unicode: FALSE);
+    });
   }
 
   public function testRejectsChildKey(): void {
@@ -71,6 +78,31 @@ final class PromptyStepKeyTest extends PromptyTestCase {
     });
 
     $this->assertSame([$key => 'plum compote'], $result);
+  }
+
+  public function testRejectsKeyThatWouldStartTheNameWithDigit(): void {
+    // An empty prefix leaves the key to start the name on its own, and a name
+    // cannot start with a digit.
+    $this->captureOutputThrows(\InvalidArgumentException::class, $this->rejection('2nd', ''), function (): void {
+      Prompty::flow(fn(): array => ['2nd' => Prompty::text('Second course', discovered: 'main')], unicode: FALSE, env_prefix: '');
+    });
+  }
+
+  public function testRejectsPrefixThatCannotBeExported(): void {
+    $this->captureOutputThrows(\InvalidArgumentException::class, $this->rejection('dish', 'MY-APP_'), function (): void {
+      Prompty::flow(fn(): array => ['dish' => Prompty::text('Dish name', discovered: 'plum compote')], unicode: FALSE, env_prefix: 'MY-APP_');
+    });
+  }
+
+  public function testAcceptsKeyStartingWithDigitBehindPrefix(): void {
+    $this->setEnvVars(['2nd' => 'main']);
+
+    $result = NULL;
+    $this->captureOutput(function () use (&$result): void {
+      $result = Prompty::flow(fn(): array => ['2nd' => Prompty::text('Second course')], unicode: FALSE);
+    });
+
+    $this->assertSame(['2nd' => 'main'], $result);
   }
 
   public static function dataProviderAcceptsKey(): \Iterator {


### PR DESCRIPTION
Closes #97

## Summary

A step's environment variable name is its key uppercased behind the configured prefix, so a step keyed `ci-provider` is looked up as `PROMPTY_CI-PROVIDER`. A parent process can still set that name directly - `env 'PROMPTY_CI-PROVIDER=x' php script.php` works - but it is not a shell identifier, so `export` rejects it as a syntax error and most `.env` parsers will not accept it either, which means the step could never be filled by the means callers actually reach for. The failure was silent rather than an error: the lookup found nothing, the step rendered its prompt, and a non-interactive process simply waited on stdin. A new `assertStepKeys()` now rejects such a step when the flow's steps are built, children included, before the terminal is touched, and the exception names both the key and the environment variable name it resolves to.

## Changes

- Added `assertStepKeys()` to `Prompty.php`, called from `flow()` right after the steps callable is evaluated, walking every step - including children reached through `__children` - and rejecting one whose resolved environment variable name is not a valid shell identifier.
- Checked the composed name (`cfgEnvPrefix` plus the uppercased key), not the key on its own: an `env_prefix` that cannot be exported made every step unfillable while the keys themselves were fine, and an empty prefix, which `configure()` accepts, leaves the key to start the name, where a leading digit is not allowed. Checking the composed name covers all three cases, and the exception message shows the name so the half at fault is visible - a key starting with a digit is accepted behind the default prefix (`PROMPTY_2ND` is exportable) but rejected behind an empty one.
- Rejected an empty step key on its own terms: it names nothing in the results and leaves the prefix standing as the whole variable name.
- Added `tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php` (13 tests) covering keys with a hyphen, dot, space and bracket; a child key; an empty key; a prefix that cannot be exported; a digit-leading key rejected behind an empty prefix and accepted behind the default one; and lowercase, underscored, mixed-case and digit-suffixed keys resolving from the environment.
- Added `playground/flow-step-keys.php`, demonstrating a flow keyed `ci-provider`, one with a child keyed `side.dish`, and a third whose keys resolve from the environment; listed it in the contributing guide's playground table.
- Documented the check in the README's environment discovery section: what the name is checked against, and that a parent process can still set a non-identifier name directly.

Run against the code before this change, the playground's first two flows are accepted and then stop at a prompt that could never have been filled. The full suite passes with the fix: 579 tests, 1377 assertions. The recorded SVG assets were regenerated and came back byte-identical.

## Before / After

```
BEFORE - a step keyed 'ci-provider' is accepted, then stalls forever
──────────────────────────────────────────────────────────────────────
flow(['ci-provider' => text('Provider')])
  (no key check runs)
  widget looks up PROMPTY_CI-PROVIDER
    export PROMPTY_CI-PROVIDER=x   -> syntax error, not a shell identifier
    a parent process can set it, but export and .env parsers cannot
  lookup finds nothing -> step renders its prompt
  non-interactive process waits on stdin indefinitely

AFTER - the same key is turned down before the terminal is touched
──────────────────────────────────────────────────────────────────────
flow(['ci-provider' => text('Provider')])
  assertStepKeys() walks the steps, children included
    name = cfgEnvPrefix . strtoupper('ci-provider')
         = 'PROMPTY_CI-PROVIDER'
    preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', name) -> no match
  throws InvalidArgumentException:
    Step "ci-provider" is looked up as the environment variable
    "PROMPTY_CI-PROVIDER", which cannot be exported. A variable name
    may hold only letters, digits and underscores, and may not start
    with a digit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Validate generated environment variable names for all flow step keys, including child steps.
- Reject empty keys, invalid prefixes, invalid characters, and invalid leading digits.
- Report both the step key and resolved environment variable name.
- Add 13 unit tests covering valid, invalid, nested, and prefixed keys.
- Add playground documentation and README guidance.
- Regenerate SVG assets.
- Full suite passes: 579 tests and 1,377 assertions.

Possibly related to `#97`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->