### PR TITLE
Put the step key examples back on the kitchen-order vocabulary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,10 +402,10 @@ The list form takes each entry literally, which is the way to select an option k
 
 For confirm widgets, env values are interpreted using configurable truthy/falsy lists (default: `1`/`true`/`yes` and `0`/`false`/`no`).
 
-A step is looked up as its key uppercased behind the prefix, so `ci_provider` reads `PROMPTY_CI_PROVIDER`. A name outside letters, digits and underscores can still be set by a parent process - `env 'PROMPTY_CI-PROVIDER=x' php your-script.php` works - but it is not a shell identifier, so `export PROMPTY_CI-PROVIDER=x` is a syntax error in bash, zsh and sh, and most `.env` parsers will not accept it. A step named that way could never be filled by the means callers actually reach for, so it is turned down when the flow starts rather than quietly never resolving:
+A step is looked up as its key uppercased behind the prefix, so `dish_name` reads `PROMPTY_DISH_NAME`. A name outside letters, digits and underscores can still be set by a parent process - `env 'PROMPTY_DISH-NAME=x' php your-script.php` works - but it is not a shell identifier, so `export PROMPTY_DISH-NAME=x` is a syntax error in bash, zsh and sh, and most `.env` parsers will not accept it. A step named that way could never be filled by the means callers actually reach for, so it is turned down when the flow starts rather than quietly never resolving:
 
 ```text
-Step "ci-provider" is looked up as the environment variable "PROMPTY_CI-PROVIDER", which cannot be exported. A variable name may hold only letters, digits and underscores, and may not start with a digit.
+Step "dish-name" is looked up as the environment variable "PROMPTY_DISH-NAME", which cannot be exported. A variable name may hold only letters, digits and underscores, and may not start with a digit.
 ```
 
 The name is what is checked, not the key alone, so an `env_prefix` that cannot be exported is caught the same way - and with an empty prefix, a key starting with a digit is too, since a name cannot.

--- a/playground/flow-step-keys.php
+++ b/playground/flow-step-keys.php
@@ -8,7 +8,7 @@
  * reads, so a step keyed 'dish_name' is pre-filled by PROMPTY_DISH_NAME.
  *
  * A name outside letters, digits and underscores can still be set by a parent
- * process - env 'PROMPTY_CI-PROVIDER=x' php script.php works - but 'export'
+ * process - env 'PROMPTY_DISH-NAME=x' php script.php works - but 'export'
  * rejects it as a syntax error and most .env parsers will not accept it. A
  * step named that way could never be filled by the means callers reach for:
  * the lookup found nothing and the flow prompted instead, saying nothing
@@ -28,11 +28,11 @@ require __DIR__ . '/../Prompty.php';
 use AlexSkrypnyk\Prompty\Prompty;
 
 echo '--- A key a shell cannot export ---' . PHP_EOL;
-echo 'Trying a flow with a step keyed "ci-provider".' . PHP_EOL;
+echo 'Trying a flow with a step keyed "dish-name".' . PHP_EOL;
 
 try {
   Prompty::flow(fn(): array => [
-    'ci-provider' => Prompty::text('Provider'),
+    'dish-name' => Prompty::text('Dish name'),
   ]);
   echo 'Accepted.' . PHP_EOL;
 }

--- a/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
+++ b/tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php
@@ -46,10 +46,10 @@ final class PromptyStepKeyTest extends PromptyTestCase {
   }
 
   public static function dataProviderRejectsKey(): \Iterator {
-    yield 'hyphen' => ['ci-provider'];
-    yield 'dot' => ['ci.provider'];
-    yield 'space' => ['ci provider'];
-    yield 'bracket' => ['ci[provider]'];
+    yield 'hyphen' => ['dish-name'];
+    yield 'dot' => ['dish.name'];
+    yield 'space' => ['dish name'];
+    yield 'bracket' => ['dish[name]'];
   }
 
   public function testRejectsEmptyKey(): void {


### PR DESCRIPTION
## Summary

Playground demos, `starter.php`, README snippets and recorded assets all follow one rule: a kitchen-order theme, with no software, product or technology references. The step-key validation examples broke that rule: they carried over a build-pipeline name (`ci_provider`, `ci-provider`, `PROMPTY_CI-PROVIDER`, and a `Provider` label) verbatim from the issue that reported the problem, rather than being translated into the demo vocabulary on the way in. This change puts them back on theme by renaming the valid key to `dish_name` and the rejected key to `dish-name`, keeping the behavior each example demonstrates identical. The contrast is arguably clearer now, since the valid and invalid keys are the same two words differing only by the hyphen.

## Changes

- `README.md`: renamed the environment discovery example from `ci_provider`/`PROMPTY_CI_PROVIDER` to `dish_name`/`PROMPTY_DISH_NAME`, and updated the quoted rejection error message from `ci-provider`/`PROMPTY_CI-PROVIDER` to `dish-name`/`PROMPTY_DISH-NAME`.
- `playground/flow-step-keys.php`: renamed the docblock's illustrative key, the echoed description line, and the actual step key and label from `ci-provider`/`Provider` to `dish-name`/`Dish name`.
- `tests/phpunit/Unit/Prompty/PromptyStepKeyTest.php`: renamed the four rejected-key data provider cases from `ci-provider`, `ci.provider`, `ci provider` and `ci[provider]` to `dish-name`, `dish.name`, `dish name` and `dish[name]`.
- Swept the rest of the example content (playground, `starter.php`, README) for the same class of reference; the only match remaining is `PHPUnit\Framework\TestCase`, a real class name in a test-harness snippet rather than example content.
- Ran the full suite: 619 tests, 1444 assertions, all passing.
- Ran `playground/flow-step-keys.php` directly to confirm the turned-down-key message reads correctly with the new names.

## Before / After

```
┌─ Valid step key ───────────────────────────────────────────────────────────┐
│ Before: ci_provider reads PROMPTY_CI_PROVIDER                              │
│ After:  dish_name reads PROMPTY_DISH_NAME                                  │
└────────────────────────────────────────────────────────────────────────────┘

┌─ Rejected step key ────────────────────────────────────────────────────────┐
│ Before: ci-provider reads PROMPTY_CI-PROVIDER, turned down                 │
│ After:  dish-name reads PROMPTY_DISH-NAME, turned down                     │
└────────────────────────────────────────────────────────────────────────────┘

┌─ Playground step label ────────────────────────────────────────────────────┐
│ Before: Provider                                                           │
│ After:  Dish name                                                          │
└────────────────────────────────────────────────────────────────────────────┘
```
