### PR TITLE
[#105] Dropped the spawn echo from the joined stream rather than per chunk.

### DIFF
--- a/.util/update-assets.php
+++ b/.util/update-assets.php
@@ -398,9 +398,8 @@ function recordSession(string $expect_script, string $cast_file, int $rows = TER
 /**
  * Post-process a cast file.
  *
- * Removes the spawn command line, rewrites the events onto a canonical
- * timeline, appends an END_PAUSE event so the animation pauses before
- * looping, and sanitizes paths.
+ * Rewrites the events onto a canonical timeline, appends an END_PAUSE event
+ * so the animation pauses before looping, and sanitizes paths.
  *
  * @param string $cast_file
  *   Path to the cast file.
@@ -411,17 +410,7 @@ function postProcessCast(string $cast_file): void {
     return;
   }
 
-  $lines = explode("\n", $content);
-  $filtered = [$lines[0]];
-  $line_count = count($lines);
-  for ($i = 1; $i < $line_count; $i++) {
-    if (str_contains($lines[$i], 'spawn ')) {
-      continue;
-    }
-    $filtered[] = $lines[$i];
-  }
-
-  $filtered = canonicaliseCast($filtered);
+  $filtered = canonicaliseCast(explode("\n", $content));
 
   // Add a pause at the end of the recording before the animation loops.
   // In asciicast v3, timestamps are relative (delta from previous event),
@@ -450,6 +439,11 @@ function postProcessCast(string $cast_file): void {
  * frame that follows within MERGE_WINDOW continues the step before it and
  * plays at FRAME_DELAY, and anything slower begins a step and plays at
  * STEP_DELAY.
+ *
+ * The spawn echo is dropped from that stream rather than from the events it
+ * arrived in, so a terminal that splits the echo, or delivers it joined to
+ * the output after it, cannot leave part of it in the render or take real
+ * output out with it.
  *
  * @param array<int, string> $lines
  *   Cast lines, the header first.
@@ -481,6 +475,8 @@ function canonicaliseCast(array $lines): array {
     $stream .= $event[2];
   }
 
+  [$stream, $arrivals] = stripSpawnEcho($stream, $arrivals);
+
   $canonical = [$header];
   $offset = 0;
   $previous = 0.0;
@@ -494,6 +490,44 @@ function canonicaliseCast(array $lines): array {
   }
 
   return $canonical;
+}
+
+/**
+ * Remove the spawn echo from the head of a session's output.
+ *
+ * Expect announces the command it spawns, so a recording opens with a line
+ * that belongs to the harness rather than to the session. The echo runs to
+ * the first line break after it.
+ *
+ * @param string $stream
+ *   The session's output.
+ * @param array<int, float> $arrivals
+ *   Times the recording captured, keyed by the offset each chunk starts at.
+ *
+ * @return array{string, array<int, float>}
+ *   The output past the echo, and the arrival times rebased onto it.
+ */
+function stripSpawnEcho(string $stream, array $arrivals): array {
+  if (!str_starts_with($stream, 'spawn ')) {
+    return [$stream, $arrivals];
+  }
+
+  $break = strpos($stream, "\n");
+
+  if ($break === FALSE) {
+    return [$stream, $arrivals];
+  }
+
+  $cut = $break + 1;
+  $rebased = [];
+
+  // A chunk that starts inside the echo holds the first output after it, so
+  // that chunk's time becomes the arrival of the rebased stream.
+  foreach ($arrivals as $start => $at) {
+    $rebased[max(0, $start - $cut)] = $at;
+  }
+
+  return [substr($stream, $cut), $rebased];
 }
 
 /**


### PR DESCRIPTION
Closes #105

## Summary

The recording harness is `expect`, driven by `asciinema rec --command=<expect script>`, and because the generated expect scripts set `log_user 1`, every recording opens with an output event containing `spawn php /path/to/playground/<script>.php <flags>` followed by a line break; that line belongs to the harness, not the recorded session, and must never reach the render. `postProcessCast()` previously removed it by dropping any cast line containing the text `spawn `, but that test was applied per recorded chunk, before the events were joined into one stream, so its correctness depended entirely on how the terminal happened to split the output. Feeding one synthetic session through `canonicaliseCast()` under three different chunkings confirmed two distinct failure modes: when the terminal splits the echo across two events, the tail of the command line (for example `--no-ansi`) survives into the render and shifts every following row down by one, which is the reported symptom against `.util/assets/widget-select-ascii-no-ansi.svg` and is especially visible on the 40-column terminals used by the static jobs, where the long command wraps; when the terminal instead delivers the echo joined to the output that follows it, the combined event still contains `spawn `, so the whole event is dropped and the session's real output goes with it, producing zero frames.

## Changes

- Added `stripSpawnEcho()`, which drops the stream's leading `spawn ` line through its first line break and rebases the arrival offsets in `$arrivals` (keyed by byte offset) past the cut, so a chunk that began inside the echo carries the first output after it and its recorded time becomes the arrival of the rebased stream.
- Called `stripSpawnEcho()` from `canonicaliseCast()`, which already concatenates every output event into one stream before cutting it into frames, so the echo is removed once the per-chunk boundaries no longer exist.
- Removed the per-chunk `spawn ` filter from `postProcessCast()` and updated both docblocks to describe the new behavior.

## Verification

- Ran the three-chunking probe against a synthetic session both before and after the fix: before, only one of the three chunkings rendered correctly, one leaked the echo, and one discarded the entire recording; after, all three chunkings produce identical frame content, with the echo absent and the body intact.
- Ran four consecutive full regenerations of all 29 assets (`php .util/update-assets.php`), each leaving `git status` clean apart from the source change: 116 asset writes, zero diffs.

## Screenshots

N/A

## Before / After

```
BEFORE - the filter runs per chunk, inside postProcessCast()

  chunk boundaries decide the outcome:

  chunking 1   ["spawn .../script.php --no-ansi\n"] ["real output..."]
                contains 'spawn ' -> dropped          no 'spawn ' -> kept
                                                        => renders correctly (by luck)

  chunking 2   ["spawn .../script.php --no-a"] ["nsi\nreal output..."]
                contains 'spawn ' -> dropped          no 'spawn ' -> kept
                                                        => "nsi" leaks into the render

  chunking 3   ["spawn .../script.php --no-ansi\nreal output..."]
                contains 'spawn ' -> entire chunk dropped
                                                        => zero frames, recording lost

AFTER - the filter runs once, on the joined stream, inside canonicaliseCast()

  every chunking joins to the same stream before filtering:

  stream = "spawn php .../script.php --no-ansi\n" + "real output..."
                                                 |
                                   stripSpawnEcho() cuts here,
                                   at the first '\n' after 'spawn '

  chunking 1, 2 and 3 all cut at the same offset in the joined stream
                                                        => identical frames every time
```
